### PR TITLE
85 se attendance in calendaragenda view

### DIFF
--- a/prisma/seed.ts
+++ b/prisma/seed.ts
@@ -24,46 +24,49 @@ async function main() {
 	await prisma.teamEvent.deleteMany();
 	await prisma.teamMember.deleteMany();
 	await prisma.team.deleteMany();
-	await prisma.account.deleteMany();
-	await prisma.session.deleteMany();
-	await prisma.user.deleteMany();
 
-	// Create 100 users
-	console.log("👥 Creating 100 users...");
-	const users = await Promise.all(
-		Array.from({ length: 100 }, async (_, i) => {
-			const userId = `user_${i + 1}_${Date.now()}`;
-			return prisma.user.create({
-				data: {
-					id: userId,
-					name: `User ${i + 1}`,
-					email: `user${i + 1}@example.com`,
-					username: `user${i + 1}`,
-					emailVerified: true,
-					isAdmin: i === 0, // First user is admin
-					image: `https://api.dicebear.com/7.x/avatars/svg?seed=${i}`,
-				},
-			});
-		}),
-	);
-	console.log(`✅ Created ${users.length} users`);
+	// Keep existing users untouched, create defaults only if none exist
+	let users = await prisma.user.findMany();
+	if (users.length === 0) {
+		console.log("👥 No users found, creating 100 users...");
+		users = await Promise.all(
+			Array.from({ length: 100 }, async (_, i) => {
+				const userId = `user_${i + 1}_${Date.now()}`;
+				return prisma.user.create({
+					data: {
+						id: userId,
+						name: `User ${i + 1}`,
+						email: `user${i + 1}@example.com`,
+						username: `user${i + 1}`,
+						emailVerified: true,
+						isAdmin: i === 0, // First user is admin
+						image: `https://api.dicebear.com/7.x/avatars/svg?seed=${i}`,
+					},
+				});
+			}),
+		);
+		console.log(`✅ Created ${users.length} users`);
+	} else {
+		console.log(`👥 Found ${users.length} existing users`);
+	}
 
-	// Create 5 teams
-	console.log("🏆 Creating 5 teams...");
-	const teamNames = [
-		"Pythons herrer",
-		"Pythons damer",
-		"Volleyball",
-		"Spring",
-		"Håndball",
+	// Create teams
+	console.log("🏆 Creating teams...");
+	const teamData = [
+		{ name: "Pythons Volley", slug: "volley" },
+		{ name: "Pythons Håndball", slug: "handball" },
+		{ name: "Pythons Fotball Herrer", slug: "pythons-gutter-a" },
+		{ name: "Pythons Fotball Damer", slug: "pythons-jenter" },
+		{ name: "TIHLDE Spring", slug: "spring" },
+		{ name: "TIHLDE Ski", slug: "tihldeski" },
 	];
 
 	const teams = await Promise.all(
-		teamNames.map((name, i) =>
+		teamData.map((team) =>
 			prisma.team.create({
 				data: {
-					name,
-					slug: name.toLowerCase().replace(/\s+/g, "-"),
+					name: team.name,
+					slug: team.slug,
 				},
 			}),
 		),

--- a/src/app/(main)/lag/[id]/_components/event-card.tsx
+++ b/src/app/(main)/lag/[id]/_components/event-card.tsx
@@ -1,13 +1,15 @@
 "use client";
 
-import type { TeamEvent, TeamEventType } from "@prisma/client";
-import { Users } from "lucide-react";
+import type { TeamEvent } from "@prisma/client";
 import type { ReactNode } from "react";
 import { useState } from "react";
-import { H2 } from "~/components/ui/typography";
+import { EventOverview } from "~/components/event-overview";
+import {
+	type AttendanceStatusFilter,
+	getEventDetailCardClassName,
+	getEventDetailSurface,
+} from "~/lib/event-presentation";
 import { cn } from "~/lib/utils";
-import { api } from "~/trpc/react";
-import EventRegistration from "./event-registration";
 import NotifyUnattended from "./notify-unattended";
 import RegistrationList from "./registration-list";
 
@@ -18,21 +20,6 @@ interface EventCardProps {
 	isAdmin?: boolean;
 }
 
-const getEventTypeLabel = (type: TeamEventType): string => {
-	switch (type) {
-		case "MATCH":
-			return "Kamp";
-		case "TRAINING":
-			return "Trening";
-		case "SOCIAL":
-			return "Sosialt";
-		case "OTHER":
-			return "Annet";
-		default:
-			return "Ukjent";
-	}
-};
-
 export default function EventCard({
 	event,
 	actions,
@@ -40,121 +27,34 @@ export default function EventCard({
 	isAdmin = false,
 }: EventCardProps) {
 	const [dialogOpen, setDialogOpen] = useState(false);
-	const [selectedStatus, setSelectedStatus] = useState<
-		"attending" | "notAttending" | "notResponded" | null
-	>(null);
+	const [selectedStatus, setSelectedStatus] =
+		useState<AttendanceStatusFilter | null>(null);
 
-	const { data: registration } = api.registration.getMyRegistration.useQuery(
-		{ eventId: event.id },
-		{ enabled: showRegistration },
-	);
-
-	const { data: counts } = api.registration.getCounts.useQuery(
-		{ eventId: event.id },
-		{ enabled: showRegistration },
-	);
-
-	const handleStatusClick = (
-		status: "attending" | "notAttending" | "notResponded",
-	) => {
+	const handleStatusClick = (status: AttendanceStatusFilter) => {
 		setSelectedStatus(status);
 		setDialogOpen(true);
 	};
 
+	const surface = getEventDetailSurface(event.eventType);
+
 	return (
 		<div
 			className={cn(
-				"space-y-4 rounded-lg p-6 text-white shadow transition-shadow hover:shadow-md",
-				event.eventType === "MATCH" &&
-					"bg-gradient-to-b from-[#6e2a70] to-[#4c126b]",
-				event.eventType === "OTHER" && "bg-card",
-				event.eventType === "SOCIAL" &&
-					"bg-gradient-to-b from-[#565220] to-[#563A20]",
-				event.eventType === "TRAINING" &&
-					"bg-gradient-to-b from-[#3A2056] to-[#0b0941]",
+				"rounded-lg p-6 shadow transition-shadow hover:shadow-md",
+				getEventDetailCardClassName(event.eventType),
 			)}
 		>
-			<div className="flex items-center justify-between">
-				<H2>{event.name}</H2>
-				{actions}
-			</div>
-			<div className="space-y-2 text-sm">
-				<p key="type">
-					<strong>Type:</strong> {getEventTypeLabel(event.eventType)}
-				</p>
-				<p key="date">
-					<strong>Fra:</strong>{" "}
-					{new Date(event.startAt).toLocaleString("nb-NO")}
-				</p>
-				<p key="date-end">
-					<strong>Til:</strong>{" "}
-					{event.endAt
-						? new Date(event.endAt).toLocaleString("nb-NO")
-						: "Ubestemt"}
-				</p>
-				<p key="location">
-					<strong>Sted:</strong> {event.location || "Ikke oppgitt"}
-				</p>
-				{event.registrationDeadline && (
-					<p key="deadline">
-						<strong>Påmeldingsfrist:</strong>{" "}
-						{new Date(event.registrationDeadline).toLocaleString("nb-NO")}
-					</p>
-				)}
-				{event.note ? (
-					<p key="note">
-						<strong>Notat:</strong> {event.note}
-					</p>
-				) : (
-					<p key="note-empty">{"\u00A0"}</p>
-				)}
-			</div>
-
-			{showRegistration && counts && (
-				<div className="border-t pt-4 text-sm">
-					<div className="grid grid-cols-3 gap-4">
-						<button
-							type="button"
-							onClick={() => handleStatusClick("attending")}
-							className="flex flex-col items-center gap-1 text-green-600 transition-opacity hover:opacity-80"
-						>
-							<Users className="h-4 w-4" />
-							<span className="text-xs">Påmeldt</span>
-							<span className="font-semibold">{counts.attending}</span>
-						</button>
-						<button
-							type="button"
-							onClick={() => handleStatusClick("notAttending")}
-							className="flex flex-col items-center gap-1 text-red-600 transition-opacity hover:opacity-80"
-						>
-							<Users className="h-4 w-4" />
-							<span className="text-xs">Avmeldt</span>
-							<span className="font-semibold">{counts.notAttending}</span>
-						</button>
-						<button
-							type="button"
-							onClick={() => handleStatusClick("notResponded")}
-							className="flex flex-col items-center gap-1 text-yellow-600 transition-opacity hover:opacity-80"
-						>
-							<Users className="h-4 w-4" />
-							<span className="text-xs">Ikke svart</span>
-							<span className="font-semibold">{counts.notResponded}</span>
-						</button>
-					</div>
-				</div>
-			)}
-
-			{showRegistration && (
-				<div className="border-t pt-4">
-					<EventRegistration
-						eventId={event.id}
-						initialRegistration={registration}
-						registrationDeadline={event.registrationDeadline}
-					/>
-				</div>
-			)}
-
-			{!showRegistration && <NotifyUnattended eventId={event.id} />}
+			<EventOverview
+				event={event}
+				headerActions={actions}
+				surface={surface}
+				showAttendanceSummary={showRegistration}
+				showRegistration={showRegistration}
+				onAttendanceStatusClick={handleStatusClick}
+				footer={
+					!showRegistration ? <NotifyUnattended eventId={event.id} /> : null
+				}
+			/>
 
 			<RegistrationList
 				eventId={event.id}

--- a/src/app/(main)/lag/[id]/_components/registration-list.tsx
+++ b/src/app/(main)/lag/[id]/_components/registration-list.tsx
@@ -7,11 +7,15 @@ import { Button } from "~/components/ui/button";
 import {
 	Dialog,
 	DialogContent,
-	DialogDescription,
 	DialogHeader,
 	DialogTitle,
 } from "~/components/ui/dialog";
 import { H3, P } from "~/components/ui/typography";
+import {
+	type AttendanceStatusFilter,
+	getAttendanceStatusLabel,
+	getAttendanceStatusTextClassName,
+} from "~/lib/event-presentation";
 import { cn } from "~/lib/utils";
 import { api } from "~/trpc/react";
 
@@ -20,7 +24,7 @@ interface RegistrationListProps {
 	eventName: string;
 	open: boolean;
 	onOpenChange: (open: boolean) => void;
-	statusFilter: "attending" | "notAttending" | "notResponded" | null;
+	statusFilter: AttendanceStatusFilter | null;
 	isAdmin?: boolean;
 }
 
@@ -79,20 +83,7 @@ export default function RegistrationList({
 			},
 		});
 
-	const getDialogTitle = () => {
-		switch (statusFilter) {
-			case "attending":
-				return "Påmeldt";
-			case "notAttending":
-				return "Avmeldt";
-			case "notResponded":
-				return "Ikke svart";
-			default:
-				return "";
-		}
-	};
-
-	const getDialogUsers = () => {
+	const dialogUsers = (() => {
 		if (statusFilter === "notResponded") {
 			return nonResponded || [];
 		}
@@ -104,12 +95,15 @@ export default function RegistrationList({
 				? r.type === "ATTENDING"
 				: r.type === "NOT_ATTENDING",
 		);
-	};
+	})();
 
 	const isLoading =
 		statusFilter === "notResponded"
 			? isLoadingNonResponded
 			: isLoadingRegistrations;
+	const dialogTitle = statusFilter
+		? getAttendanceStatusLabel(statusFilter)
+		: "";
 
 	return (
 		<Dialog open={open} onOpenChange={onOpenChange}>
@@ -122,18 +116,16 @@ export default function RegistrationList({
 					<H3
 						className={cn(
 							"mb-3",
-							statusFilter === "attending" && "text-green-600",
-							statusFilter === "notAttending" && "text-red-600",
-							statusFilter === "notResponded" && "text-yellow-600",
+							statusFilter && getAttendanceStatusTextClassName(statusFilter),
 						)}
 					>
-						{getDialogTitle()} ({getDialogUsers().length})
+						{dialogTitle} ({dialogUsers.length})
 					</H3>
-					{getDialogUsers().length === 0 ? (
+					{dialogUsers.length === 0 ? (
 						<P className="text-muted-foreground">Ingen personer</P>
 					) : (
 						<div className="grid grid-cols-1 gap-2 md:grid-cols-2 lg:grid-cols-3">
-							{getDialogUsers().map((item: Registration | NonRespondedUser) => {
+							{dialogUsers.map((item: Registration | NonRespondedUser) => {
 								const isRegistration = "comment" in item;
 								const registration = isRegistration
 									? (item as Registration)

--- a/src/components/event-calendar/event-dialog.tsx
+++ b/src/components/event-calendar/event-dialog.tsx
@@ -1,10 +1,7 @@
 "use client";
 
-import { format } from "date-fns";
-import { nb } from "date-fns/locale";
-
 import type { TeamEvent } from "@prisma/client";
-import EventRegistration from "~/app/(main)/lag/[id]/_components/event-registration";
+import { EventOverview } from "~/components/event-overview";
 import { Button } from "~/components/ui/button";
 import {
 	Dialog,
@@ -13,35 +10,6 @@ import {
 	DialogHeader,
 	DialogTitle,
 } from "~/components/ui/dialog";
-import { api } from "~/trpc/react";
-
-const getEventTypeLabel = (type: string): string => {
-	switch (type) {
-		case "MATCH":
-			return "Kamp";
-		case "TRAINING":
-			return "Trening";
-		case "SOCIAL":
-			return "Sosialt";
-		case "OTHER":
-			return "Annet";
-		default:
-			return type;
-	}
-};
-
-const getEventTypeBgClass = (type: string): string => {
-	switch (type) {
-		case "MATCH":
-			return "bg-gradient-to-b from-[#6e2a70] to-[#4c126b]";
-		case "SOCIAL":
-			return "bg-gradient-to-b from-[#565220] to-[#563A20]";
-		case "TRAINING":
-			return "bg-gradient-to-b from-[#3A2056] to-[#0b0941]";
-		default:
-			return "bg-card";
-	}
-};
 
 interface EventDialogProps {
 	event: TeamEvent | null;
@@ -52,11 +20,6 @@ interface EventDialogProps {
 }
 
 export function EventDialog({ event, isOpen, onClose }: EventDialogProps) {
-	const { data: registration } = api.registration.getMyRegistration.useQuery(
-		{ eventId: event?.id || "" },
-		{ enabled: !!event && isOpen },
-	);
-
 	if (!event) {
 		return null;
 	}
@@ -64,96 +27,17 @@ export function EventDialog({ event, isOpen, onClose }: EventDialogProps) {
 	return (
 		<Dialog open={isOpen} onOpenChange={(open) => !open && onClose()}>
 			<DialogContent className="max-h-[90vh] overflow-y-auto sm:max-w-2xl">
-				<DialogHeader>
-					<DialogTitle className="font-bold text-3xl">{event.name}</DialogTitle>
-					<DialogDescription className="sr-only">
-						Event details and registration
-					</DialogDescription>
+				<DialogHeader className="sr-only">
+					<DialogTitle>{event.name}</DialogTitle>
+					<DialogDescription>Event details and registration</DialogDescription>
 				</DialogHeader>
 
-				<div className="space-y-6">
-					{/* Event Type Badge */}
-					<div className="flex items-center gap-2">
-						<span
-							className={`inline-block rounded-full px-3 py-1 font-medium text-sm text-white ${getEventTypeBgClass(event.eventType)}`}
-						>
-							{getEventTypeLabel(event.eventType)}
-						</span>
-					</div>
+				<EventOverview
+					event={event}
+					showAttendanceSummary={isOpen}
+					showRegistration={isOpen}
+				/>
 
-					{/* Date and Time */}
-					<div>
-						<h3 className="mb-1 font-semibold text-muted-foreground text-sm">
-							Dato og tid
-						</h3>
-						<p className="text-base">
-							{format(new Date(event.startAt), "EEEE d. MMMM yyyy", {
-								locale: nb,
-							})}
-						</p>
-						<p className="text-muted-foreground text-sm">
-							{format(new Date(event.startAt), "HH:mm", { locale: nb })} -{" "}
-							{format(new Date(event.endAt || event.startAt), "HH:mm", {
-								locale: nb,
-							})}
-						</p>
-					</div>
-
-					{/* Location */}
-					{event.location && (
-						<div>
-							<h3 className="mb-1 font-semibold text-muted-foreground text-sm">
-								Sted
-							</h3>
-							<p className="text-base">{event.location}</p>
-						</div>
-					)}
-
-					{/* Registration Deadline */}
-					{event.registrationDeadline && (
-						<div>
-							<h3 className="mb-1 font-semibold text-muted-foreground text-sm">
-								Påmeldingsfrist
-							</h3>
-							<p className="text-base">
-								{format(
-									new Date(event.registrationDeadline),
-									"d. MMM yyyy HH:mm",
-									{
-										locale: nb,
-									},
-								)}
-							</p>
-						</div>
-					)}
-
-					{/* Description/Notes */}
-					{event.note && (
-						<div>
-							<h3 className="mb-1 font-semibold text-muted-foreground text-sm">
-								Beskrivelse
-							</h3>
-							<p className="whitespace-pre-wrap text-base leading-relaxed">
-								{event.note}
-							</p>
-						</div>
-					)}
-
-					{/* Divider */}
-					<div className="border-t" />
-
-					{/* Registration Component */}
-					<div>
-						<h3 className="mb-4 font-semibold text-lg">Påmelding</h3>
-						<EventRegistration
-							eventId={event.id}
-							initialRegistration={registration}
-							registrationDeadline={event.registrationDeadline}
-						/>
-					</div>
-				</div>
-
-				{/* Close Button */}
 				<div className="flex justify-end gap-2 border-t pt-4">
 					<Button variant="outline" onClick={onClose}>
 						Lukk

--- a/src/components/event-overview.tsx
+++ b/src/components/event-overview.tsx
@@ -1,0 +1,263 @@
+"use client";
+
+import type { TeamEvent } from "@prisma/client";
+import { format } from "date-fns";
+import { nb } from "date-fns/locale";
+import { Users } from "lucide-react";
+import type { ReactNode } from "react";
+import EventRegistration from "~/app/(main)/lag/[id]/_components/event-registration";
+import {
+	type AttendanceStatusFilter,
+	type EventOverviewSurface,
+	attendanceStatusOrder,
+	getAttendanceStatusAccentClassName,
+	getAttendanceStatusLabel,
+	getEventDateTime,
+	getEventTypeBadgeClassName,
+	getEventTypeLabel,
+} from "~/lib/event-presentation";
+import { cn } from "~/lib/utils";
+import { api } from "~/trpc/react";
+
+interface EventOverviewProps {
+	event: TeamEvent;
+	headerActions?: ReactNode;
+	surface?: EventOverviewSurface;
+	showAttendanceSummary?: boolean;
+	showRegistration?: boolean;
+	onAttendanceStatusClick?: (status: AttendanceStatusFilter) => void;
+	footer?: ReactNode;
+}
+
+interface EventInfoBlockProps {
+	label: string;
+	children: ReactNode;
+	labelClassName: string;
+	valueClassName: string;
+	className?: string;
+}
+
+interface AttendanceSummaryItemProps {
+	count: number;
+	label: string;
+	onClick?: () => void;
+	surface: EventOverviewSurface;
+	status: AttendanceStatusFilter;
+}
+
+function EventInfoBlock({
+	label,
+	children,
+	labelClassName,
+	valueClassName,
+	className,
+}: EventInfoBlockProps) {
+	return (
+		<div className={cn("space-y-1.5", className)}>
+			<p className={cn("font-semibold text-sm", labelClassName)}>{label}</p>
+			<div
+				className={cn("text-sm leading-relaxed sm:text-base", valueClassName)}
+			>
+				{children}
+			</div>
+		</div>
+	);
+}
+
+function AttendanceSummaryItem({
+	count,
+	label,
+	onClick,
+	surface,
+	status,
+}: AttendanceSummaryItemProps) {
+	const isInteractive = typeof onClick === "function";
+	const summaryCardClassName =
+		surface === "inverse"
+			? "border-white/10 bg-white/5 text-white"
+			: "border-border bg-muted/30 text-foreground";
+	const summaryLabelClassName =
+		surface === "inverse" ? "text-white/70" : "text-muted-foreground";
+
+	const content = (
+		<>
+			<div className="flex items-center gap-2 font-medium text-xs">
+				<Users
+					className={cn(
+						"h-3.5 w-3.5",
+						getAttendanceStatusAccentClassName(status, surface),
+					)}
+				/>
+				<span className={summaryLabelClassName}>{label}</span>
+			</div>
+			<p className="mt-2 font-semibold text-2xl leading-none">{count}</p>
+		</>
+	);
+
+	if (!isInteractive) {
+		return (
+			<div className={cn("rounded-lg border p-3", summaryCardClassName)}>
+				{content}
+			</div>
+		);
+	}
+
+	return (
+		<button
+			type="button"
+			onClick={onClick}
+			className={cn(
+				"rounded-lg border p-3 text-left transition-colors focus-visible:border-ring focus-visible:ring-[3px] focus-visible:ring-ring/50",
+				surface === "inverse" ? "hover:bg-white/10" : "hover:bg-muted/50",
+				summaryCardClassName,
+			)}
+		>
+			{content}
+		</button>
+	);
+}
+
+export function EventOverview({
+	event,
+	headerActions,
+	surface = "default",
+	showAttendanceSummary = false,
+	showRegistration = false,
+	onAttendanceStatusClick,
+	footer,
+}: EventOverviewProps) {
+	const eventDateTime = getEventDateTime(event);
+	const titleClassName =
+		surface === "inverse" ? "text-white" : "text-foreground";
+	const labelClassName =
+		surface === "inverse" ? "text-white/70" : "text-muted-foreground";
+	const valueClassName =
+		surface === "inverse" ? "text-white" : "text-foreground";
+	const secondaryValueClassName =
+		surface === "inverse" ? "text-white/80" : "text-muted-foreground";
+	const sectionBorderClassName =
+		surface === "inverse" ? "border-white/15" : "border-border";
+
+	const { data: registration } = api.registration.getMyRegistration.useQuery(
+		{ eventId: event.id },
+		{ enabled: showRegistration },
+	);
+
+	const { data: counts } = api.registration.getCounts.useQuery(
+		{ eventId: event.id },
+		{ enabled: showAttendanceSummary },
+	);
+
+	return (
+		<div className="space-y-6">
+			<div className="flex items-start justify-between gap-4">
+				<div className="min-w-0 space-y-3">
+					<h2
+						className={cn(
+							"text-balance font-semibold text-2xl tracking-tight sm:text-3xl",
+							titleClassName,
+						)}
+					>
+						{event.name}
+					</h2>
+					<span
+						className={cn(
+							"inline-flex rounded-full px-3 py-1 font-medium text-sm",
+							getEventTypeBadgeClassName(event.eventType),
+							event.eventType === "OTHER" ? "" : "text-white",
+						)}
+					>
+						{getEventTypeLabel(event.eventType)}
+					</span>
+				</div>
+				{headerActions && <div className="shrink-0">{headerActions}</div>}
+			</div>
+
+			<div className="grid gap-4 sm:grid-cols-2">
+				<EventInfoBlock
+					label="Dato og tid"
+					labelClassName={labelClassName}
+					valueClassName={valueClassName}
+				>
+					<p>{eventDateTime.primary}</p>
+					<p className={secondaryValueClassName}>{eventDateTime.secondary}</p>
+				</EventInfoBlock>
+
+				<EventInfoBlock
+					label="Sted"
+					labelClassName={labelClassName}
+					valueClassName={valueClassName}
+				>
+					{event.location || "Ikke oppgitt"}
+				</EventInfoBlock>
+
+				{event.registrationDeadline && (
+					<EventInfoBlock
+						label="Påmeldingsfrist"
+						labelClassName={labelClassName}
+						valueClassName={valueClassName}
+					>
+						{format(
+							new Date(event.registrationDeadline),
+							"d. MMMM yyyy 'kl.' HH:mm",
+							{
+								locale: nb,
+							},
+						)}
+					</EventInfoBlock>
+				)}
+
+				{event.note && (
+					<EventInfoBlock
+						label="Beskrivelse"
+						labelClassName={labelClassName}
+						valueClassName={valueClassName}
+						className="sm:col-span-2"
+					>
+						<p className="whitespace-pre-wrap">{event.note}</p>
+					</EventInfoBlock>
+				)}
+			</div>
+
+			{showAttendanceSummary && counts && (
+				<div className={cn("border-t pt-6", sectionBorderClassName)}>
+					<div className="grid grid-cols-3 gap-3">
+						{attendanceStatusOrder.map((status) => (
+							<AttendanceSummaryItem
+								key={status}
+								count={counts[status]}
+								label={getAttendanceStatusLabel(status)}
+								onClick={
+									onAttendanceStatusClick
+										? () => onAttendanceStatusClick(status)
+										: undefined
+								}
+								surface={surface}
+								status={status}
+							/>
+						))}
+					</div>
+				</div>
+			)}
+
+			{showRegistration && (
+				<div className={cn("border-t pt-6", sectionBorderClassName)}>
+					<h3 className={cn("mb-4 font-semibold text-lg", titleClassName)}>
+						Påmelding
+					</h3>
+					<EventRegistration
+						eventId={event.id}
+						initialRegistration={registration}
+						registrationDeadline={event.registrationDeadline}
+					/>
+				</div>
+			)}
+
+			{footer && (
+				<div className={cn("border-t pt-6", sectionBorderClassName)}>
+					{footer}
+				</div>
+			)}
+		</div>
+	);
+}

--- a/src/components/event-overview.tsx
+++ b/src/components/event-overview.tsx
@@ -10,8 +10,8 @@ import {
 	type AttendanceStatusFilter,
 	type EventOverviewSurface,
 	attendanceStatusOrder,
-	getAttendanceStatusAccentClassName,
 	getAttendanceStatusLabel,
+	getAttendanceStatusTextClassName,
 	getEventDateTime,
 	getEventTypeBadgeClassName,
 	getEventTypeLabel,
@@ -41,7 +41,6 @@ interface AttendanceSummaryItemProps {
 	count: number;
 	label: string;
 	onClick?: () => void;
-	surface: EventOverviewSurface;
 	status: AttendanceStatusFilter;
 }
 
@@ -68,36 +67,20 @@ function AttendanceSummaryItem({
 	count,
 	label,
 	onClick,
-	surface,
 	status,
 }: AttendanceSummaryItemProps) {
 	const isInteractive = typeof onClick === "function";
-	const summaryCardClassName =
-		surface === "inverse"
-			? "border-white/10 bg-white/5 text-white"
-			: "border-border bg-muted/30 text-foreground";
-	const summaryLabelClassName =
-		surface === "inverse" ? "text-white/70" : "text-muted-foreground";
-
-	const content = (
-		<>
-			<div className="flex items-center gap-2 font-medium text-xs">
-				<Users
-					className={cn(
-						"h-3.5 w-3.5",
-						getAttendanceStatusAccentClassName(status, surface),
-					)}
-				/>
-				<span className={summaryLabelClassName}>{label}</span>
-			</div>
-			<p className="mt-2 font-semibold text-2xl leading-none">{count}</p>
-		</>
+	const summaryClassName = cn(
+		"flex flex-col items-center gap-1",
+		getAttendanceStatusTextClassName(status),
 	);
 
 	if (!isInteractive) {
 		return (
-			<div className={cn("rounded-lg border p-3", summaryCardClassName)}>
-				{content}
+			<div className={summaryClassName}>
+				<Users className="h-4 w-4" />
+				<span className="text-xs">{label}</span>
+				<span className="font-semibold">{count}</span>
 			</div>
 		);
 	}
@@ -107,12 +90,13 @@ function AttendanceSummaryItem({
 			type="button"
 			onClick={onClick}
 			className={cn(
-				"rounded-lg border p-3 text-left transition-colors focus-visible:border-ring focus-visible:ring-[3px] focus-visible:ring-ring/50",
-				surface === "inverse" ? "hover:bg-white/10" : "hover:bg-muted/50",
-				summaryCardClassName,
+				summaryClassName,
+				"transition-opacity hover:opacity-80 focus-visible:border-ring focus-visible:ring-[3px] focus-visible:ring-ring/50",
 			)}
 		>
-			{content}
+			<Users className="h-4 w-4" />
+			<span className="text-xs">{label}</span>
+			<span className="font-semibold">{count}</span>
 		</button>
 	);
 }
@@ -221,7 +205,7 @@ export function EventOverview({
 
 			{showAttendanceSummary && counts && (
 				<div className={cn("border-t pt-6", sectionBorderClassName)}>
-					<div className="grid grid-cols-3 gap-3">
+					<div className="grid grid-cols-3 gap-4 text-sm">
 						{attendanceStatusOrder.map((status) => (
 							<AttendanceSummaryItem
 								key={status}
@@ -232,7 +216,6 @@ export function EventOverview({
 										? () => onAttendanceStatusClick(status)
 										: undefined
 								}
-								surface={surface}
 								status={status}
 							/>
 						))}

--- a/src/components/navigation/unanswered-events-dropdown.tsx
+++ b/src/components/navigation/unanswered-events-dropdown.tsx
@@ -15,22 +15,8 @@ import {
 	DropdownMenuSeparator,
 	DropdownMenuTrigger,
 } from "~/components/ui/dropdown-menu";
+import { getEventTypeLabel } from "~/lib/event-presentation";
 import { api } from "~/trpc/react";
-
-const getEventTypeLabel = (type: string): string => {
-	switch (type) {
-		case "MATCH":
-			return "Kamp";
-		case "TRAINING":
-			return "Trening";
-		case "SOCIAL":
-			return "Sosialt";
-		case "OTHER":
-			return "Annet";
-		default:
-			return type;
-	}
-};
 
 export default function UnansweredEventsDropdown() {
 	const { data: unansweredEvents } = api.event.getUnanswered.useQuery();

--- a/src/lib/event-presentation.ts
+++ b/src/lib/event-presentation.ts
@@ -1,0 +1,136 @@
+import type { TeamEvent, TeamEventType } from "@prisma/client";
+import { format, isSameDay } from "date-fns";
+import { nb } from "date-fns/locale";
+
+export type AttendanceStatusFilter =
+	| "attending"
+	| "notAttending"
+	| "notResponded";
+
+export type EventOverviewSurface = "default" | "inverse";
+
+export const attendanceStatusOrder: AttendanceStatusFilter[] = [
+	"attending",
+	"notAttending",
+	"notResponded",
+];
+
+const eventTypePresentation: Record<
+	TeamEventType,
+	{
+		label: string;
+		badgeClassName: string;
+		cardClassName: string;
+		surface: EventOverviewSurface;
+	}
+> = {
+	MATCH: {
+		label: "Kamp",
+		badgeClassName: "bg-gradient-to-b from-[#6e2a70] to-[#4c126b]",
+		cardClassName: "bg-gradient-to-b from-[#6e2a70] to-[#4c126b] text-white",
+		surface: "inverse",
+	},
+	TRAINING: {
+		label: "Trening",
+		badgeClassName: "bg-gradient-to-b from-[#3A2056] to-[#0b0941]",
+		cardClassName: "bg-gradient-to-b from-[#3A2056] to-[#0b0941] text-white",
+		surface: "inverse",
+	},
+	SOCIAL: {
+		label: "Sosialt",
+		badgeClassName: "bg-gradient-to-b from-[#565220] to-[#563A20]",
+		cardClassName: "bg-gradient-to-b from-[#565220] to-[#563A20] text-white",
+		surface: "inverse",
+	},
+	OTHER: {
+		label: "Annet",
+		badgeClassName: "border bg-card text-card-foreground",
+		cardClassName: "border bg-card text-card-foreground",
+		surface: "default",
+	},
+};
+
+export function getEventTypeLabel(type: TeamEventType): string {
+	return eventTypePresentation[type]?.label ?? "Ukjent";
+}
+
+export function getEventTypeBadgeClassName(type: TeamEventType): string {
+	return (
+		eventTypePresentation[type]?.badgeClassName ??
+		eventTypePresentation.OTHER.badgeClassName
+	);
+}
+
+export function getEventDetailCardClassName(type: TeamEventType): string {
+	return (
+		eventTypePresentation[type]?.cardClassName ??
+		eventTypePresentation.OTHER.cardClassName
+	);
+}
+
+export function getEventDetailSurface(
+	type: TeamEventType,
+): EventOverviewSurface {
+	return eventTypePresentation[type]?.surface ?? "default";
+}
+
+export function getAttendanceStatusLabel(
+	status: AttendanceStatusFilter,
+): string {
+	switch (status) {
+		case "attending":
+			return "Påmeldt";
+		case "notAttending":
+			return "Avmeldt";
+		case "notResponded":
+			return "Ikke svart";
+	}
+}
+
+export function getAttendanceStatusTextClassName(
+	status: AttendanceStatusFilter,
+): string {
+	switch (status) {
+		case "attending":
+			return "text-green-600";
+		case "notAttending":
+			return "text-red-600";
+		case "notResponded":
+			return "text-yellow-600";
+	}
+}
+
+export function getAttendanceStatusAccentClassName(
+	status: AttendanceStatusFilter,
+	surface: EventOverviewSurface,
+): string {
+	switch (status) {
+		case "attending":
+			return surface === "inverse" ? "text-emerald-200" : "text-emerald-600";
+		case "notAttending":
+			return surface === "inverse" ? "text-rose-200" : "text-rose-600";
+		case "notResponded":
+			return surface === "inverse" ? "text-amber-200" : "text-amber-600";
+	}
+}
+
+export function getEventDateTime(event: Pick<TeamEvent, "startAt" | "endAt">) {
+	const startAt = new Date(event.startAt);
+	const endAt = new Date(event.endAt || event.startAt);
+
+	if (isSameDay(startAt, endAt)) {
+		return {
+			primary: format(startAt, "EEEE d. MMMM yyyy", { locale: nb }),
+			secondary: `${format(startAt, "HH:mm", { locale: nb })} - ${format(endAt, "HH:mm", { locale: nb })}`,
+		};
+	}
+
+	return {
+		primary: `Fra ${format(startAt, "EEEE d. MMMM yyyy 'kl.' HH:mm", {
+			locale: nb,
+		})}`,
+		secondary: `Til ${format(endAt, "EEEE d. MMMM yyyy 'kl.' HH:mm", {
+			locale: nb,
+		})}`,
+	};
+}


### PR DESCRIPTION
Har lagt til et nytt seed-script som bruker riktige slugs, slik at dataene blir konsistente og vi får hentet medlemskap.

Har også refaktorert visningen av event-detaljer for å fjerne duplisert kode. Nå bruker popup/modal og siden under /lag/[id] samme struktur for å vise eventer. Informasjon om eventet, oppmøtestatus og påmeldingsvalg vises likt overalt, både i felles kalender, lagvisning og admin.

Til slutt har vi samlet logikk for hvordan eventtyper, oppmøtestatus og formatering av eventdetaljer vises. Dette gjør at vi slipper å definere det flere steder, spesielt i dropdowns og dialoger.