### PR TITLE
Fix/92 view attendance insteadof send notification

### DIFF
--- a/prisma/migrations/20260413120000_registration_attendance_flags/migration.sql
+++ b/prisma/migrations/20260413120000_registration_attendance_flags/migration.sql
@@ -1,0 +1,50 @@
+ALTER TABLE "registration" DROP COLUMN IF EXISTS "confirmedAbsent";
+ALTER TABLE "registration" DROP COLUMN IF EXISTS "attendedWithoutRsvp";
+
+DO $$
+BEGIN
+  CREATE TYPE "AttendanceStatus" AS ENUM ('PRESENT', 'ABSENT');
+EXCEPTION
+  WHEN duplicate_object THEN NULL;
+END $$;
+
+DO $$
+BEGIN
+  CREATE TYPE "AttendanceSource" AS ENUM ('RSVP', 'MANUAL');
+EXCEPTION
+  WHEN duplicate_object THEN NULL;
+END $$;
+
+CREATE TABLE IF NOT EXISTS "attendance" (
+  "id" TEXT NOT NULL,
+  "userId" TEXT NOT NULL,
+  "eventId" TEXT NOT NULL,
+  "status" "AttendanceStatus" NOT NULL,
+  "source" "AttendanceSource" NOT NULL DEFAULT 'RSVP',
+  "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  "updatedAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  CONSTRAINT "attendance_pkey" PRIMARY KEY ("id")
+);
+
+CREATE UNIQUE INDEX IF NOT EXISTS "attendance_userId_eventId_key"
+ON "attendance"("userId", "eventId");
+
+DO $$
+BEGIN
+  ALTER TABLE "attendance"
+  ADD CONSTRAINT "attendance_userId_fkey"
+  FOREIGN KEY ("userId") REFERENCES "user"("id")
+  ON DELETE CASCADE ON UPDATE CASCADE;
+EXCEPTION
+  WHEN duplicate_object THEN NULL;
+END $$;
+
+DO $$
+BEGIN
+  ALTER TABLE "attendance"
+  ADD CONSTRAINT "attendance_eventId_fkey"
+  FOREIGN KEY ("eventId") REFERENCES "team_event"("id")
+  ON DELETE CASCADE ON UPDATE CASCADE;
+EXCEPTION
+  WHEN duplicate_object THEN NULL;
+END $$;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -11,13 +11,13 @@ datasource db {
 }
 
 model User {
-  id            String  @id
-  name          String
-  email         String
-  emailVerified Boolean @default(true)
-  image         String?
-  isAdmin       Boolean @default(false)
-  username      String? @unique
+  id                        String  @id
+  name                      String
+  email                     String
+  emailVerified             Boolean @default(true)
+  image                     String?
+  isAdmin                   Boolean @default(false)
+  username                  String? @unique
   emailNotificationsEnabled Boolean @default(true)
 
   createdAt         DateTime           @default(now())
@@ -26,6 +26,7 @@ model User {
   accounts          Account[]
   memberships       TeamMember[]
   registrations     Registration[]
+  attendances       Attendance[]
   pushSubscriptions PushSubscription[]
 
   @@unique([email])
@@ -124,6 +125,7 @@ model TeamEvent {
   registrationDeadline DateTime?
   team                 Team           @relation(fields: [teamId], references: [id], onDelete: Cascade)
   registrations        Registration[]
+  attendances          Attendance[]
 
   createdAt DateTime @default(now())
   updatedAt DateTime @default(now()) @updatedAt
@@ -157,6 +159,32 @@ model Registration {
 enum RegistrationType {
   ATTENDING
   NOT_ATTENDING
+}
+
+model Attendance {
+  id      String           @id @default(cuid())
+  userId  String
+  eventId String
+  status  AttendanceStatus
+  source  AttendanceSource @default(RSVP)
+  user    User             @relation(fields: [userId], references: [id], onDelete: Cascade)
+  event   TeamEvent        @relation(fields: [eventId], references: [id], onDelete: Cascade)
+
+  createdAt DateTime @default(now())
+  updatedAt DateTime @default(now()) @updatedAt
+
+  @@unique([userId, eventId])
+  @@map("attendance")
+}
+
+enum AttendanceStatus {
+  PRESENT
+  ABSENT
+}
+
+enum AttendanceSource {
+  RSVP
+  MANUAL
 }
 
 model PushSubscription {

--- a/src/app/(main)/lag/[id]/_components/confirm-event-attendance.tsx
+++ b/src/app/(main)/lag/[id]/_components/confirm-event-attendance.tsx
@@ -1,0 +1,68 @@
+"use client";
+
+import type { RegistrationType } from "@prisma/client";
+import { Avatar, AvatarFallback, AvatarImage } from "~/components/ui/avatar";
+import {
+	Dialog,
+	DialogContent,
+	DialogDescription,
+	DialogHeader,
+	DialogTitle,
+} from "~/components/ui/dialog";
+import { P } from "~/components/ui/typography";
+import { api } from "~/trpc/react";
+
+interface ConfirmEventAttendanceProps {
+	eventId: string;
+	eventName: string;
+	open: boolean;
+	onOpenChange: (open: boolean) => void;
+}
+
+export default function ConfirmEventAttendance({
+	eventId,
+	eventName,
+	open,
+	onOpenChange,
+}: ConfirmEventAttendanceProps) {
+	const { data: registrations, isLoading } =
+		api.registration.getAllByEvent.useQuery({ eventId }, { enabled: open });
+
+	const attending = (registrations ?? []).filter(
+		(r: { type: RegistrationType }) => r.type === "ATTENDING",
+	);
+
+	return (
+		<Dialog open={open} onOpenChange={onOpenChange}>
+			<DialogContent className="max-h-[80vh] overflow-y-auto sm:max-w-4xl">
+				<DialogHeader>
+					<DialogTitle>Se oppmøte</DialogTitle>
+					<DialogDescription>{eventName}</DialogDescription>
+				</DialogHeader>
+
+				{isLoading ? (
+					<div className="py-8 text-center">
+						<P className="text-muted-foreground">Laster...</P>
+					</div>
+				) : attending.length === 0 ? (
+					<P className="text-muted-foreground">Ingen var påmeldt som kommer.</P>
+				) : (
+					<div className="grid grid-cols-1 gap-2 md:grid-cols-2 lg:grid-cols-3">
+						{attending.map((row) => (
+							<div
+								key={row.id}
+								className="flex items-center gap-3 rounded-lg border bg-card p-3"
+							>
+								<Avatar>
+									<AvatarImage src={row.user.image ?? undefined} alt={row.user.name} />
+									<AvatarFallback>{row.user.name[0]}</AvatarFallback>
+								</Avatar>
+								<div className="font-medium">{row.user.name}</div>
+							</div>
+						))}
+					</div>
+				)}
+			</DialogContent>
+		</Dialog>
+	);
+}

--- a/src/app/(main)/lag/[id]/_components/confirm-event-attendance.tsx
+++ b/src/app/(main)/lag/[id]/_components/confirm-event-attendance.tsx
@@ -1,7 +1,10 @@
 "use client";
 
 import type { RegistrationType } from "@prisma/client";
+import { useState } from "react";
+import { toast } from "sonner";
 import { Avatar, AvatarFallback, AvatarImage } from "~/components/ui/avatar";
+import { Button } from "~/components/ui/button";
 import {
 	Dialog,
 	DialogContent,
@@ -9,58 +12,279 @@ import {
 	DialogHeader,
 	DialogTitle,
 } from "~/components/ui/dialog";
+import {
+	Select,
+	SelectContent,
+	SelectItem,
+	SelectTrigger,
+	SelectValue,
+} from "~/components/ui/select";
 import { P } from "~/components/ui/typography";
 import { api } from "~/trpc/react";
+
+type UserPreview = { id: string; name: string; image: string | null };
+
+type RegistrationRow = {
+	id: string;
+	type: RegistrationType;
+	confirmedAbsent: boolean;
+	attendedWithoutRsvp: boolean;
+	user: UserPreview;
+};
 
 interface ConfirmEventAttendanceProps {
 	eventId: string;
 	eventName: string;
 	open: boolean;
 	onOpenChange: (open: boolean) => void;
+	isAdmin?: boolean;
 }
+
+type Tab = "present" | "absent";
 
 export default function ConfirmEventAttendance({
 	eventId,
 	eventName,
 	open,
 	onOpenChange,
+	isAdmin = false,
 }: ConfirmEventAttendanceProps) {
+	const [tab, setTab] = useState<Tab>("present");
+	const [selectedWithoutRsvpUserId, setSelectedWithoutRsvpUserId] =
+		useState<string>("");
+	const utils = api.useUtils();
+
 	const { data: registrations, isLoading } =
 		api.registration.getAllByEvent.useQuery({ eventId }, { enabled: open });
 
+	const { data: eligibleWithoutRsvp, isLoading: loadingEligibleWithoutRsvp } =
+		api.registration.getEligibleWithoutRsvp.useQuery(
+			{ eventId },
+			{ enabled: open && isAdmin },
+		);
+
+	const { mutate: setConfirmedAbsentMutation, isPending } =
+		api.registration.setConfirmedAbsent.useMutation({
+			onSuccess: (_, variables) => {
+				toast.success(
+					variables.confirmedAbsent
+						? "Fravær er registrert"
+						: "Fravær er fjernet",
+				);
+				utils.registration.getAllByEvent.invalidate({ eventId });
+				utils.registration.getEligibleWithoutRsvp.invalidate({ eventId });
+			},
+			onError: (error) => {
+				toast.error(error.message || "Kunne ikke oppdatere oppmøte");
+			},
+		});
+
+	const { mutate: addAttendanceWithoutRsvp, isPending: isAddingWithoutRsvp } =
+		api.registration.addAttendanceWithoutRsvp.useMutation({
+			onSuccess: () => {
+				toast.success("Lagt til som møtt opp");
+				setSelectedWithoutRsvpUserId("");
+				utils.registration.getAllByEvent.invalidate({ eventId });
+				utils.registration.getCounts.invalidate({ eventId });
+				utils.registration.getNonResponded.invalidate({ eventId });
+				utils.registration.getEligibleWithoutRsvp.invalidate({ eventId });
+			},
+			onError: (error) => {
+				toast.error(error.message || "Kunne ikke legge til");
+			},
+		});
+
 	const attending = (registrations ?? []).filter(
-		(r: { type: RegistrationType }) => r.type === "ATTENDING",
+		(r: RegistrationRow) => r.type === "ATTENDING",
 	);
+	const present = attending.filter((r: RegistrationRow) => !r.confirmedAbsent);
+	const absent = attending.filter((r: RegistrationRow) => r.confirmedAbsent);
+
+	const list = tab === "present" ? present : absent;
 
 	return (
-		<Dialog open={open} onOpenChange={onOpenChange}>
+		<Dialog
+			open={open}
+			onOpenChange={(next) => {
+				onOpenChange(next);
+				if (!next) {
+					setTab("present");
+					setSelectedWithoutRsvpUserId("");
+				}
+			}}
+		>
 			<DialogContent className="max-h-[80vh] overflow-y-auto sm:max-w-4xl">
 				<DialogHeader>
-					<DialogTitle>Se oppmøte</DialogTitle>
+					<DialogTitle>
+						{isAdmin ? "Bekreft oppmøte" : "Se oppmøte"}
+					</DialogTitle>
 					<DialogDescription>{eventName}</DialogDescription>
 				</DialogHeader>
+
+				<P className="text-muted-foreground text-sm">
+					{isAdmin
+						? "Under «Møtte opp» vises påmeldte som «kommer». Du kan registrere fravær, eller legge til medlemmer som møtte uten å melde seg på (eller som var avmeldt)."
+						: "Listen følger påmelding. Medlemmer merket «Uten påmelding» er lagt inn av leder fordi de møtte uten å være påmeldt som «kommer»."}
+				</P>
 
 				{isLoading ? (
 					<div className="py-8 text-center">
 						<P className="text-muted-foreground">Laster...</P>
 					</div>
-				) : attending.length === 0 ? (
-					<P className="text-muted-foreground">Ingen var påmeldt som kommer.</P>
 				) : (
-					<div className="grid grid-cols-1 gap-2 md:grid-cols-2 lg:grid-cols-3">
-						{attending.map((row) => (
-							<div
-								key={row.id}
-								className="flex items-center gap-3 rounded-lg border bg-card p-3"
+					<>
+						<div className="flex gap-2">
+							<Button
+								type="button"
+								variant={tab === "present" ? "default" : "outline"}
+								className="flex-1"
+								onClick={() => setTab("present")}
 							>
-								<Avatar>
-									<AvatarImage src={row.user.image ?? undefined} alt={row.user.name} />
-									<AvatarFallback>{row.user.name[0]}</AvatarFallback>
-								</Avatar>
-								<div className="font-medium">{row.user.name}</div>
-							</div>
-						))}
-					</div>
+								Møtte opp ({present.length})
+							</Button>
+							<Button
+								type="button"
+								variant={tab === "absent" ? "default" : "outline"}
+								className="flex-1"
+								onClick={() => setTab("absent")}
+							>
+								Møtte ikke ({absent.length})
+							</Button>
+						</div>
+
+						<div className="space-y-4">
+							{list.length === 0 ? (
+								<P className="text-muted-foreground">
+									{tab === "present"
+										? "Ingen påmeldt som kommer, eller alle er registrert som ikke møtt."
+										: "Ingen er registrert som ikke møtt."}
+								</P>
+							) : (
+								<div className="grid grid-cols-1 gap-2 md:grid-cols-2 lg:grid-cols-3">
+									{list.map((row: RegistrationRow) => (
+										<div
+											key={row.id}
+											className="flex flex-col gap-2 rounded-lg border bg-card p-3"
+										>
+											<div className="flex items-center gap-3">
+												<Avatar>
+													<AvatarImage
+														src={row.user.image ?? undefined}
+														alt={row.user.name}
+													/>
+													<AvatarFallback>{row.user.name[0]}</AvatarFallback>
+												</Avatar>
+												<div className="min-w-0 flex-1">
+													<div className="font-medium leading-tight">
+														{row.user.name}
+													</div>
+													{row.attendedWithoutRsvp && (
+														<div className="text-muted-foreground text-xs">
+															Uten påmelding
+														</div>
+													)}
+												</div>
+											</div>
+											{isAdmin && tab === "present" && (
+												<Button
+													type="button"
+													size="sm"
+													variant="outline"
+													className="w-full"
+													disabled={isPending}
+													onClick={() =>
+														setConfirmedAbsentMutation({
+															eventId,
+															userId: row.user.id,
+															confirmedAbsent: true,
+														})
+													}
+												>
+													Møtte ikke
+												</Button>
+											)}
+											{isAdmin && tab === "absent" && (
+												<Button
+													type="button"
+													size="sm"
+													variant="outline"
+													className="w-full"
+													disabled={isPending}
+													onClick={() =>
+														setConfirmedAbsentMutation({
+															eventId,
+															userId: row.user.id,
+															confirmedAbsent: false,
+														})
+													}
+												>
+													Opphev (møtte likevel)
+												</Button>
+											)}
+										</div>
+									))}
+								</div>
+							)}
+							{isAdmin && tab === "present" && (
+								<div className="space-y-2 rounded-md border border-dashed p-3">
+									<P className="font-medium text-sm">
+										Legg til som møtte uten påmelding
+									</P>
+									<P className="text-muted-foreground text-xs">
+										Gjelder medlemmer som ikke var påmeldt som «kommer», eller
+										som var avmeldt.
+									</P>
+									{loadingEligibleWithoutRsvp ? (
+										<P className="text-muted-foreground text-xs">
+											Laster medlemmer…
+										</P>
+									) : !eligibleWithoutRsvp?.length ? (
+										<P className="text-muted-foreground text-xs">
+											Ingen flere som kan legges til herfra (alle er allerede
+											påmeldt som kommer).
+										</P>
+									) : (
+										<div className="flex flex-col gap-2 sm:flex-row sm:items-end">
+											<div className="min-w-0 flex-1">
+												<Select
+													value={selectedWithoutRsvpUserId || undefined}
+													onValueChange={setSelectedWithoutRsvpUserId}
+												>
+													<SelectTrigger>
+														<SelectValue placeholder="Velg medlem" />
+													</SelectTrigger>
+													<SelectContent>
+														{eligibleWithoutRsvp.map((u: UserPreview) => (
+															<SelectItem key={u.id} value={u.id}>
+																{u.name}
+															</SelectItem>
+														))}
+													</SelectContent>
+												</Select>
+											</div>
+											<Button
+												type="button"
+												className="shrink-0 sm:w-auto"
+												disabled={
+													!selectedWithoutRsvpUserId ||
+													isAddingWithoutRsvp ||
+													isPending
+												}
+												onClick={() =>
+													addAttendanceWithoutRsvp({
+														eventId,
+														userId: selectedWithoutRsvpUserId,
+													})
+												}
+											>
+												Legg til
+											</Button>
+										</div>
+									)}
+								</div>
+							)}
+						</div>
+					</>
 				)}
 			</DialogContent>
 		</Dialog>

--- a/src/app/(main)/lag/[id]/_components/event-card.tsx
+++ b/src/app/(main)/lag/[id]/_components/event-card.tsx
@@ -4,12 +4,14 @@ import type { TeamEvent } from "@prisma/client";
 import type { ReactNode } from "react";
 import { useState } from "react";
 import { EventOverview } from "~/components/event-overview";
+import { Button } from "~/components/ui/button";
 import {
 	type AttendanceStatusFilter,
 	getEventDetailCardClassName,
 	getEventDetailSurface,
 } from "~/lib/event-presentation";
 import { cn } from "~/lib/utils";
+import ConfirmEventAttendance from "./confirm-event-attendance";
 import NotifyUnattended from "./notify-unattended";
 import RegistrationList from "./registration-list";
 
@@ -27,8 +29,12 @@ export default function EventCard({
 	isAdmin = false,
 }: EventCardProps) {
 	const [dialogOpen, setDialogOpen] = useState(false);
+	const [confirmAttendanceOpen, setConfirmAttendanceOpen] = useState(false);
 	const [selectedStatus, setSelectedStatus] =
 		useState<AttendanceStatusFilter | null>(null);
+
+	const now = new Date();
+	const isPastEvent = new Date(event.endAt ?? event.startAt) < now;
 
 	const handleStatusClick = (status: AttendanceStatusFilter) => {
 		setSelectedStatus(status);
@@ -52,8 +58,34 @@ export default function EventCard({
 				showRegistration={showRegistration}
 				onAttendanceStatusClick={handleStatusClick}
 				footer={
-					!showRegistration ? <NotifyUnattended eventId={event.id} /> : null
+					isAdmin && !isPastEvent ? (
+						<NotifyUnattended eventId={event.id} />
+					) : null
 				}
+			/>
+
+			{isPastEvent && (
+				<div className="border-t pt-6">
+					<Button
+						type="button"
+						variant="outline"
+						className={cn(
+							"w-full",
+							event.eventType !== "OTHER" &&
+								"border-white/80 bg-white/10 text-white hover:bg-white/20 hover:text-white",
+						)}
+						onClick={() => setConfirmAttendanceOpen(true)}
+					>
+						Se oppmøte
+					</Button>
+				</div>
+			)}
+
+			<ConfirmEventAttendance
+				eventId={event.id}
+				eventName={event.name}
+				open={confirmAttendanceOpen}
+				onOpenChange={setConfirmAttendanceOpen}
 			/>
 
 			<RegistrationList

--- a/src/app/(main)/lag/[id]/_components/event-card.tsx
+++ b/src/app/(main)/lag/[id]/_components/event-card.tsx
@@ -76,7 +76,7 @@ export default function EventCard({
 						)}
 						onClick={() => setConfirmAttendanceOpen(true)}
 					>
-						Se oppmøte
+						{isAdmin ? "Bekreft oppmøte" : "Se oppmøte"}
 					</Button>
 				</div>
 			)}
@@ -86,6 +86,7 @@ export default function EventCard({
 				eventName={event.name}
 				open={confirmAttendanceOpen}
 				onOpenChange={setConfirmAttendanceOpen}
+				isAdmin={isAdmin}
 			/>
 
 			<RegistrationList

--- a/src/app/(main)/lag/[id]/admin/page.tsx
+++ b/src/app/(main)/lag/[id]/admin/page.tsx
@@ -74,6 +74,7 @@ export default async function EventsAdminPage({ params }: EventPageProps) {
 							key={event.id}
 							event={event}
 							actions={<EditEvent event={event} teamId={id} />}
+							isAdmin
 						/>
 					))}
 				</div>

--- a/src/schemas/registration.ts
+++ b/src/schemas/registration.ts
@@ -43,3 +43,18 @@ export const notifyUnattendedEventRegistrationSchema = z.object({
 	eventId: z.string().min(1, "Event ID er påkrevd"),
 	teamId: z.string().min(1, "Team ID er påkrevd"),
 });
+
+export const addAttendanceWithoutRsvpSchema = z.object({
+	eventId: z.string().min(1, "Event ID er påkrevd"),
+	userId: z.string().min(1, "User ID er påkrevd"),
+});
+
+export const setConfirmedAbsentSchema = z.object({
+	eventId: z.string().min(1, "Event ID er påkrevd"),
+	userId: z.string().min(1, "User ID er påkrevd"),
+	confirmedAbsent: z.boolean(),
+});
+
+export const getEligibleWithoutRsvpSchema = z.object({
+	eventId: z.string().min(1, "Event ID er påkrevd"),
+});

--- a/src/server/api/registration/controller/add-attendance-without-rsvp.ts
+++ b/src/server/api/registration/controller/add-attendance-without-rsvp.ts
@@ -1,0 +1,57 @@
+import type { User } from "@prisma/client";
+import { TRPCError } from "@trpc/server";
+import type z from "zod";
+import { addAttendanceWithoutRsvpSchema } from "~/schemas/registration";
+import { db } from "~/server/db";
+import { type Controller, authorizedProcedure } from "../../trpc";
+import { hasTeamAccessMiddleware } from "../../util/auth";
+
+const handler: Controller<
+	z.infer<typeof addAttendanceWithoutRsvpSchema>,
+	void
+> = async ({ input, ctx }) => {
+	const event = await db.teamEvent.findUnique({
+		where: { id: input.eventId },
+		select: { teamId: true },
+	});
+
+	if (!event) {
+		throw new TRPCError({
+			code: "NOT_FOUND",
+			message: "Arrangement ikke funnet",
+		});
+	}
+
+	await hasTeamAccessMiddleware(ctx.user as User, event.teamId, [
+		"ADMIN",
+		"SUBADMIN",
+	]);
+
+	const membership = await db.teamMember.findUnique({
+		where: {
+			userId_teamId: { userId: input.userId, teamId: event.teamId },
+		},
+	});
+
+	if (!membership) {
+		throw new TRPCError({
+			code: "NOT_FOUND",
+			message: "Brukeren er ikke medlem av laget",
+		});
+	}
+
+	await db.attendance.upsert({
+		where: { userId_eventId: { userId: input.userId, eventId: input.eventId } },
+		create: {
+			userId: input.userId,
+			eventId: input.eventId,
+			status: "PRESENT",
+			source: "MANUAL",
+		},
+		update: { status: "PRESENT", source: "MANUAL" },
+	});
+};
+
+export default authorizedProcedure
+	.input(addAttendanceWithoutRsvpSchema)
+	.mutation(handler);

--- a/src/server/api/registration/controller/create.ts
+++ b/src/server/api/registration/controller/create.ts
@@ -44,8 +44,6 @@ const handler: Controller<
 		},
 	});
 
-	console.log("User membership:", userMembership);
-
 	const isAdmin =
 		userMembership?.role === "ADMIN" || userMembership?.role === "SUBADMIN";
 

--- a/src/server/api/registration/controller/get-all-by-event.ts
+++ b/src/server/api/registration/controller/get-all-by-event.ts
@@ -10,7 +10,6 @@ const handler: Controller<
 	z.infer<typeof getRegistrationByEventSchema>,
 	any
 > = async ({ input, ctx }) => {
-	// Get the event to check team access
 	const event = await db.teamEvent.findUnique({
 		where: { id: input.eventId },
 		select: { teamId: true },
@@ -23,30 +22,56 @@ const handler: Controller<
 		});
 	}
 
-	// Check if user has access to the team
 	await hasTeamAccessMiddleware(ctx.user as User, event.teamId, [
 		"ADMIN",
 		"SUBADMIN",
 		"USER",
 	]);
 
-	return await db.registration.findMany({
-		where: {
-			eventId: input.eventId,
-		},
-		include: {
-			user: {
-				select: {
-					id: true,
-					name: true,
-					image: true,
-				},
+	const [registrations, attendances] = await Promise.all([
+		db.registration.findMany({
+			where: { eventId: input.eventId },
+			include: {
+				user: { select: { id: true, name: true, image: true } },
 			},
-		},
-		orderBy: {
-			createdAt: "asc",
-		},
-	});
+			orderBy: { createdAt: "asc" },
+		}),
+		db.attendance.findMany({
+			where: { eventId: input.eventId },
+			include: {
+				user: { select: { id: true, name: true, image: true } },
+			},
+		}),
+	]);
+
+	const absentUserIds = new Set(
+		attendances.filter((a) => a.status === "ABSENT").map((a) => a.userId),
+	);
+	const attendingUserIds = new Set(
+		registrations.filter((r) => r.type === "ATTENDING").map((r) => r.userId),
+	);
+
+	return [
+		...registrations.map((reg) => ({
+			...reg,
+			confirmedAbsent: absentUserIds.has(reg.userId),
+			attendedWithoutRsvp: false,
+		})),
+		...attendances
+			.filter((a) => a.source === "MANUAL" && !attendingUserIds.has(a.userId))
+			.map((a) => ({
+				id: a.id,
+				type: "ATTENDING" as const,
+				confirmedAbsent: a.status === "ABSENT",
+				attendedWithoutRsvp: true,
+				userId: a.userId,
+				eventId: a.eventId,
+				comment: null,
+				user: a.user,
+				createdAt: a.createdAt,
+				updatedAt: a.updatedAt,
+			})),
+	].sort((a, b) => a.createdAt.getTime() - b.createdAt.getTime());
 };
 
 export default authorizedProcedure

--- a/src/server/api/registration/controller/get-eligible-without-rsvp.ts
+++ b/src/server/api/registration/controller/get-eligible-without-rsvp.ts
@@ -1,0 +1,62 @@
+import type { User } from "@prisma/client";
+import { TRPCError } from "@trpc/server";
+import type z from "zod";
+import { getEligibleWithoutRsvpSchema } from "~/schemas/registration";
+import { db } from "~/server/db";
+import { type Controller, authorizedProcedure } from "../../trpc";
+import { hasTeamAccessMiddleware } from "../../util/auth";
+
+type EligibleUser = { id: string; name: string; image: string | null };
+
+const handler: Controller<
+	z.infer<typeof getEligibleWithoutRsvpSchema>,
+	EligibleUser[]
+> = async ({ input, ctx }) => {
+	const event = await db.teamEvent.findUnique({
+		where: { id: input.eventId },
+		select: { teamId: true },
+	});
+
+	if (!event) {
+		throw new TRPCError({
+			code: "NOT_FOUND",
+			message: "Arrangement ikke funnet",
+		});
+	}
+
+	await hasTeamAccessMiddleware(ctx.user as User, event.teamId, [
+		"ADMIN",
+		"SUBADMIN",
+	]);
+
+	const [attendingUserIds, manualPresentUserIds] = await Promise.all([
+		db.registration
+			.findMany({
+				where: { eventId: input.eventId, type: "ATTENDING" },
+				select: { userId: true },
+			})
+			.then((rows) => new Set(rows.map((r) => r.userId))),
+		db.attendance
+			.findMany({
+				where: { eventId: input.eventId, source: "MANUAL", status: "PRESENT" },
+				select: { userId: true },
+			})
+			.then((rows) => new Set(rows.map((a) => a.userId))),
+	]);
+
+	const excluded = new Set([...attendingUserIds, ...manualPresentUserIds]);
+
+	const teamMembers = await db.teamMember.findMany({
+		where: {
+			teamId: event.teamId,
+			userId: { notIn: [...excluded] },
+		},
+		select: { user: { select: { id: true, name: true, image: true } } },
+	});
+
+	return teamMembers.map((m) => m.user);
+};
+
+export default authorizedProcedure
+	.input(getEligibleWithoutRsvpSchema)
+	.query(handler);

--- a/src/server/api/registration/controller/set-confirmed-absent.ts
+++ b/src/server/api/registration/controller/set-confirmed-absent.ts
@@ -1,0 +1,67 @@
+import type { User } from "@prisma/client";
+import { TRPCError } from "@trpc/server";
+import type z from "zod";
+import { setConfirmedAbsentSchema } from "~/schemas/registration";
+import { db } from "~/server/db";
+import { type Controller, authorizedProcedure } from "../../trpc";
+import { hasTeamAccessMiddleware } from "../../util/auth";
+
+const handler: Controller<
+	z.infer<typeof setConfirmedAbsentSchema>,
+	void
+> = async ({ input, ctx }) => {
+	const event = await db.teamEvent.findUnique({
+		where: { id: input.eventId },
+		select: { teamId: true },
+	});
+
+	if (!event) {
+		throw new TRPCError({
+			code: "NOT_FOUND",
+			message: "Arrangement ikke funnet",
+		});
+	}
+
+	await hasTeamAccessMiddleware(ctx.user as User, event.teamId, [
+		"ADMIN",
+		"SUBADMIN",
+	]);
+
+	if (input.confirmedAbsent) {
+		await db.attendance.upsert({
+			where: {
+				userId_eventId: { userId: input.userId, eventId: input.eventId },
+			},
+			create: {
+				userId: input.userId,
+				eventId: input.eventId,
+				status: "ABSENT",
+				source: "RSVP",
+			},
+			update: { status: "ABSENT" },
+		});
+	} else {
+		const existing = await db.attendance.findUnique({
+			where: {
+				userId_eventId: { userId: input.userId, eventId: input.eventId },
+			},
+			select: { source: true },
+		});
+		if (existing?.source === "MANUAL") {
+			await db.attendance.update({
+				where: {
+					userId_eventId: { userId: input.userId, eventId: input.eventId },
+				},
+				data: { status: "PRESENT" },
+			});
+		} else {
+			await db.attendance.deleteMany({
+				where: { userId: input.userId, eventId: input.eventId },
+			});
+		}
+	}
+};
+
+export default authorizedProcedure
+	.input(setConfirmedAbsentSchema)
+	.mutation(handler);

--- a/src/server/api/registration/router.ts
+++ b/src/server/api/registration/router.ts
@@ -1,11 +1,14 @@
 import { createTRPCRouter } from "../trpc";
+import addAttendanceWithoutRsvp from "./controller/add-attendance-without-rsvp";
 import adminUpdate from "./controller/admin-update";
 import create from "./controller/create";
 import deleteRegistration from "./controller/delete";
 import getAllByEvent from "./controller/get-all-by-event";
 import getCounts from "./controller/get-counts";
+import getEligibleWithoutRsvp from "./controller/get-eligible-without-rsvp";
 import getMyRegistration from "./controller/get-my-registration";
 import getNonResponded from "./controller/get-non-responded";
+import setConfirmedAbsent from "./controller/set-confirmed-absent";
 
 export const registrationRouter = createTRPCRouter({
 	create,
@@ -15,4 +18,7 @@ export const registrationRouter = createTRPCRouter({
 	getCounts,
 	getNonResponded,
 	adminUpdate,
+	setConfirmedAbsent,
+	addAttendanceWithoutRsvp,
+	getEligibleWithoutRsvp,
 });

--- a/src/server/api/team/controller/get-attendance-stats.ts
+++ b/src/server/api/team/controller/get-attendance-stats.ts
@@ -1,5 +1,6 @@
 import { TRPCError } from "@trpc/server";
 import { z } from "zod";
+import { isEventPast } from "~/server/api/util/event";
 import { type Controller, authorizedProcedure } from "../../trpc";
 
 const inputSchema = z.object({
@@ -36,50 +37,63 @@ const handler: Controller<
 		});
 	}
 
-	// Get all team members
-	const teamMembers = await ctx.db.teamMember.findMany({
-		where: {
-			teamId,
-		},
-		include: {
-			user: {
-				select: {
-					id: true,
-					name: true,
-					image: true,
+	const [teamMembers, teamEvents] = await Promise.all([
+		ctx.db.teamMember.findMany({
+			where: { teamId },
+			include: {
+				user: {
+					select: {
+						id: true,
+						name: true,
+						image: true,
+					},
 				},
 			},
-		},
-	});
-
-	// Get all events for the team
-	const teamEvents = await ctx.db.teamEvent.findMany({
-		where: {
-			teamId,
-		},
-		select: {
-			id: true,
-		},
-	});
+		}),
+		ctx.db.teamEvent.findMany({
+			where: { teamId },
+			select: { id: true, startAt: true, endAt: true },
+		}),
+	]);
 
 	const totalEvents = teamEvents.length;
 	const eventIds = teamEvents.map((e) => e.id);
+	const eventMap = new Map(teamEvents.map((e) => [e.id, e]));
 
-	// Get all registrations for team events
-	const registrations = await ctx.db.registration.findMany({
-		where: {
-			eventId: {
-				in: eventIds,
-			},
-			type: "ATTENDING",
-		},
-		select: {
-			userId: true,
-		},
-	});
+	const [registrations, absences, manualAttendances] = await Promise.all([
+		ctx.db.registration.findMany({
+			where: { eventId: { in: eventIds }, type: "ATTENDING" },
+			select: { userId: true, eventId: true },
+		}),
+		ctx.db.attendance
+			.findMany({
+				where: { eventId: { in: eventIds }, status: "ABSENT" },
+				select: { userId: true, eventId: true },
+			})
+			.then((rows) => new Set(rows.map((a) => `${a.userId}:${a.eventId}`))),
+		ctx.db.attendance.findMany({
+			where: { eventId: { in: eventIds }, status: "PRESENT", source: "MANUAL" },
+			select: { userId: true, eventId: true },
+		}),
+	]);
+
+	const registrationKeys = new Set(
+		registrations.map((r) => `${r.userId}:${r.eventId}`),
+	);
+
+	const countsAsAttendance: { userId: string }[] = [
+		...registrations.filter((reg) => {
+			const event = eventMap.get(reg.eventId);
+			if (!event || !isEventPast(event)) return true;
+			return !absences.has(`${reg.userId}:${reg.eventId}`);
+		}),
+		...manualAttendances.filter(
+			(a) => !registrationKeys.has(`${a.userId}:${a.eventId}`),
+		),
+	];
 
 	// Count attendances per user
-	const attendanceCounts = registrations.reduce(
+	const attendanceCounts = countsAsAttendance.reduce(
 		(acc, reg) => {
 			acc[reg.userId] = (acc[reg.userId] || 0) + 1;
 			return acc;

--- a/src/server/api/util/event.ts
+++ b/src/server/api/util/event.ts
@@ -1,0 +1,9 @@
+export function isEventPast(event: {
+	endAt: Date | null;
+	startAt: Date;
+}): boolean {
+	if (event.endAt) {
+		return event.endAt < new Date();
+	}
+	return event.startAt < new Date();
+}


### PR DESCRIPTION
Fikser buggen hvor Send påminnelse vises for tidligere arrangementer. Har endret slik at kun admins ser det under fremtidige arrangementer. 
I stedet er det nå 'Se oppmøte' for tidligere arrangementer.


La også til en ny, eksperimentell feature for tidligere arrangementer hvor spesielt admins kan dokumentere de som faktisk møtte opp til ulike events. Alle som registrerte seg til å komme vises som 'Møtte opp', og da kan trenere loggføre medlemmer som ikke kom likevel, eller legge til folk som ikke var påmeldt på forhånd. Tenkte det kunne være noe som kan kobles til et mulig botsystem.

Den nye featuren var bare en tanke, og hvis det ikke er nødvendig funksjonalitet er det bare å scrappe commit 2 og kun beholde bugfixen i commit 1
