### PR TITLE
Feat/86 google cal integration

### DIFF
--- a/package.json
+++ b/package.json
@@ -50,6 +50,7 @@
 		"class-variance-authority": "^0.7.1",
 		"clsx": "^2.1.1",
 		"date-fns": "^4.1.0",
+		"ical-generator": "^10.2.0",
 		"lucide-react": "^0.544.0",
 		"next": "^15.2.3",
 		"next-themes": "^0.4.6",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -86,6 +86,9 @@ importers:
       date-fns:
         specifier: ^4.1.0
         version: 4.1.0
+      ical-generator:
+        specifier: ^10.2.0
+        version: 10.2.0(@types/node@20.19.17)
       lucide-react:
         specifier: ^0.544.0
         version: 0.544.0(react@19.1.1)
@@ -1594,6 +1597,39 @@ packages:
   https-proxy-agent@7.0.6:
     resolution: {integrity: sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==}
     engines: {node: '>= 14'}
+
+  ical-generator@10.2.0:
+    resolution: {integrity: sha512-XR5FsiDWCsz5MwBwMA/sQqR3A9H240xkXIeXOabV7uNAiieP+TA9rleVvlwPLRXMz+CXME8cGuDd7cdnE5At6w==}
+    engines: {node: 20 || 22 || >=24}
+    peerDependencies:
+      '@touch4it/ical-timezones': '>=1.6.0'
+      '@types/luxon': '>= 1.26.0'
+      '@types/mocha': '>= 8.2.1'
+      '@types/node': '*'
+      dayjs: '>= 1.10.0'
+      luxon: '>= 1.26.0'
+      moment: '>= 2.29.0'
+      moment-timezone: '>= 0.5.33'
+      rrule: '>= 2.6.8'
+    peerDependenciesMeta:
+      '@touch4it/ical-timezones':
+        optional: true
+      '@types/luxon':
+        optional: true
+      '@types/mocha':
+        optional: true
+      '@types/node':
+        optional: true
+      dayjs:
+        optional: true
+      luxon:
+        optional: true
+      moment:
+        optional: true
+      moment-timezone:
+        optional: true
+      rrule:
+        optional: true
 
   inherits@2.0.4:
     resolution: {integrity: sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==}
@@ -3367,6 +3403,10 @@ snapshots:
       debug: 4.4.3
     transitivePeerDependencies:
       - supports-color
+
+  ical-generator@10.2.0(@types/node@20.19.17):
+    optionalDependencies:
+      '@types/node': 20.19.17
 
   inherits@2.0.4: {}
 

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -19,6 +19,7 @@ model User {
   isAdmin       Boolean @default(false)
   username      String? @unique
   emailNotificationsEnabled Boolean @default(true)
+  calendarToken     String?  @unique
 
   createdAt         DateTime           @default(now())
   updatedAt         DateTime           @default(now()) @updatedAt

--- a/src/app/(main)/_components/calendar-subscribe-dialog.tsx
+++ b/src/app/(main)/_components/calendar-subscribe-dialog.tsx
@@ -1,0 +1,159 @@
+"use client";
+
+import {
+	CalendarDays,
+	Check,
+	Copy,
+	ExternalLink,
+	RefreshCw,
+} from "lucide-react";
+import { useState } from "react";
+import { Button } from "~/components/ui/button";
+import {
+	Dialog,
+	DialogContent,
+	DialogDescription,
+	DialogHeader,
+	DialogTitle,
+	DialogTrigger,
+} from "~/components/ui/dialog";
+import { Input } from "~/components/ui/input";
+import { api } from "~/trpc/react";
+
+export function CalendarSubscribeDialog() {
+	const [copied, setCopied] = useState(false);
+	const [confirmRegen, setConfirmRegen] = useState(false);
+
+	const { data, refetch } = api.me.calendar.getOrCreateToken.useQuery();
+	const regenerate = api.me.calendar.regenerateToken.useMutation({
+		onSuccess: () => {
+			void refetch();
+			setConfirmRegen(false);
+		},
+	});
+
+	const feedUrl =
+		typeof window !== "undefined" && data?.token
+			? `${window.location.origin}/api/calendar/${data.token}`
+			: "";
+
+	const handleCopy = async () => {
+		if (!feedUrl) return;
+		await navigator.clipboard.writeText(feedUrl);
+		setCopied(true);
+		setTimeout(() => setCopied(false), 2000);
+	};
+
+	const googleCalUrl = feedUrl
+		? `https://www.google.com/calendar/render?cid=${encodeURIComponent(feedUrl.replace("https://", "webcal://"))}`
+		: "";
+
+	return (
+		<Dialog>
+			<DialogTrigger asChild>
+				<Button variant="outline" size="sm" className="gap-2">
+					<CalendarDays size={16} />
+					Abonner på kalender
+				</Button>
+			</DialogTrigger>
+			<DialogContent className="max-w-md">
+				<DialogHeader>
+					<DialogTitle>Abonner på kalender</DialogTitle>
+					<DialogDescription>
+						Legg til dine treninger og kamper i Google Calendar, Apple Calendar
+						eller Outlook. Hendelser du har svart «ikke tilstede» på vises ikke.
+					</DialogDescription>
+				</DialogHeader>
+
+				<div className="space-y-4 pt-2">
+					<div className="space-y-2">
+						<p className="font-medium text-sm">Abonnementslenke</p>
+						<div className="flex gap-2">
+							<Input
+								readOnly
+								value={feedUrl}
+								className="font-mono text-xs"
+								onClick={(e) => (e.target as HTMLInputElement).select()}
+							/>
+							<Button
+								size="icon"
+								variant="outline"
+								onClick={handleCopy}
+								disabled={!feedUrl}
+								title="Kopier lenke"
+							>
+								{copied ? <Check size={16} /> : <Copy size={16} />}
+							</Button>
+						</div>
+					</div>
+
+					<div className="flex flex-col gap-2">
+						<p className="font-medium text-sm">Legg til i kalender</p>
+						<Button
+							variant="outline"
+							className="w-full justify-start gap-2"
+							disabled={!googleCalUrl}
+							onClick={() => window.open(googleCalUrl, "_blank")}
+						>
+							<ExternalLink size={16} />
+							Legg til i Google Calendar
+						</Button>
+						<Button
+							variant="outline"
+							className="w-full justify-start gap-2"
+							disabled={!feedUrl}
+							onClick={() =>
+								window.open(
+									feedUrl
+										.replace("https://", "webcal://")
+										.replace("http://", "webcal://"),
+									"_blank",
+								)
+							}
+						>
+							<ExternalLink size={16} />
+							Legg til i Apple Calendar / Outlook
+						</Button>
+					</div>
+
+					<div className="border-t pt-2">
+						{confirmRegen ? (
+							<div className="space-y-2">
+								<p className="text-muted-foreground text-sm">
+									Er du sikker? Den gamle lenken vil slutte å fungere.
+								</p>
+								<div className="flex gap-2">
+									<Button
+										size="sm"
+										variant="destructive"
+										onClick={() => regenerate.mutate()}
+										disabled={regenerate.isPending}
+									>
+										{regenerate.isPending ? "Genererer..." : "Ja, generer ny"}
+									</Button>
+									<Button
+										size="sm"
+										variant="outline"
+										onClick={() => setConfirmRegen(false)}
+									>
+										Avbryt
+									</Button>
+								</div>
+							</div>
+						) : (
+							<Button
+								size="sm"
+								variant="ghost"
+								className="gap-2 text-muted-foreground"
+								onClick={() => setConfirmRegen(true)}
+							>
+								<RefreshCw size={14} />
+								Generer ny lenke
+							</Button>
+						)}
+					</div>
+				</div>
+			</DialogContent>
+		</Dialog>
+	);
+}

--- a/src/app/(main)/_components/calendar.tsx
+++ b/src/app/(main)/_components/calendar.tsx
@@ -3,6 +3,7 @@
 import type { TeamEvent } from "@prisma/client";
 import { useRouter, useSearchParams } from "next/navigation";
 import { type CalendarView, EventCalendar } from "~/components/event-calendar";
+import { CalendarSubscribeDialog } from "./calendar-subscribe-dialog";
 
 interface MyCalendarProps {
 	events: TeamEvent[];
@@ -44,6 +45,9 @@ export default function MyCalendar({
 	return (
 		<div className="w-full px-2 py-20 md:px-6 md:py-32 lg:px-12">
 			<div className="mx-auto w-full max-w-7xl">
+				<div className="mb-4 flex justify-end">
+					<CalendarSubscribeDialog />
+				</div>
 				<EventCalendar
 					events={events}
 					initialView={initialView || "agenda"}

--- a/src/app/(main)/_components/rsvp-toast.tsx
+++ b/src/app/(main)/_components/rsvp-toast.tsx
@@ -1,0 +1,33 @@
+"use client";
+
+import { usePathname, useRouter, useSearchParams } from "next/navigation";
+import { useEffect, useRef } from "react";
+import { toast } from "sonner";
+
+export function RsvpToast() {
+	const searchParams = useSearchParams();
+	const pathname = usePathname();
+	const router = useRouter();
+	const processedRef = useRef<string | null>(null);
+
+	useEffect(() => {
+		const rsvp = searchParams.get("rsvp");
+		const key = searchParams.toString();
+		if (!rsvp || processedRef.current === key) return;
+
+		processedRef.current = key;
+
+		if (rsvp === "ATTENDING") {
+			toast.success("Du er påmeldt!");
+		} else if (rsvp === "NOT_ATTENDING") {
+			toast.info("Du er avmeldt.");
+		}
+
+		const params = new URLSearchParams(searchParams.toString());
+		params.delete("rsvp");
+		const search = params.size > 0 ? `?${params.toString()}` : "";
+		router.replace(`${pathname}${search}`, { scroll: false });
+	}, [searchParams, pathname, router]);
+
+	return null;
+}

--- a/src/app/(main)/lag/[id]/page.tsx
+++ b/src/app/(main)/lag/[id]/page.tsx
@@ -4,7 +4,7 @@ import type { User } from "@prisma/client";
 import { ArrowRight, BarChart3, PackageOpen, UsersRound } from "lucide-react";
 import { headers } from "next/headers";
 import Link from "next/link";
-import { notFound } from "next/navigation";
+import { notFound, redirect } from "next/navigation";
 import { Button } from "~/components/ui/button";
 import { H1, H2, P } from "~/components/ui/typography";
 import { auth } from "~/lib/auth";
@@ -35,7 +35,7 @@ export default async function TeamPage({
 		headers: await headers(),
 	});
 
-	if (!session) notFound();
+	if (!session) redirect("/");
 
 	const membership = await hasTeamAccess(id, session.user as User);
 

--- a/src/app/(main)/layout.tsx
+++ b/src/app/(main)/layout.tsx
@@ -1,8 +1,10 @@
 import type { Metadata } from "next";
+import { Suspense } from "react";
 
 import BottomBar from "~/components/navigation/bottom-bar";
 import Footer from "~/components/navigation/footer";
 import Navbar from "~/components/navigation/top-bar";
+import { RsvpToast } from "./_components/rsvp-toast";
 
 export const metadata: Metadata = {
 	title: "Idrett | TIHLDE",
@@ -16,6 +18,9 @@ export default async function RootLayout({
 }>) {
 	return (
 		<div className="relative min-h-dvh">
+			<Suspense>
+				<RsvpToast />
+			</Suspense>
 			<Navbar />
 			<main className="w-full">{children}</main>
 			<BottomBar />

--- a/src/app/api/calendar/[token]/route.ts
+++ b/src/app/api/calendar/[token]/route.ts
@@ -4,7 +4,7 @@ import { getEventTypeLabel } from "~/lib/event-presentation";
 import { db } from "~/server/db";
 
 export async function GET(
-	_request: Request,
+	request: Request,
 	{ params }: { params: Promise<{ token: string }> },
 ) {
 	const { token } = await params;
@@ -33,6 +33,7 @@ export async function GET(
 							eventType: true,
 							startAt: true,
 							endAt: true,
+							updatedAt: true,
 							location: true,
 							note: true,
 							registrations: {
@@ -47,6 +48,7 @@ export async function GET(
 	});
 
 	const baseUrl = env.NEXT_PUBLIC_URL ?? "https://sporty.tihlde.org";
+	const rsvpTokenBase = `${baseUrl}/api/rsvp/${token}`;
 
 	const calendar = ical({
 		name: `TIHLDE Idrett – ${user.name}`,
@@ -58,25 +60,44 @@ export async function GET(
 		const { team } = membership;
 
 		for (const event of team.events) {
-			if (event.registrations[0]?.type === "NOT_ATTENDING") continue;
+			const registration = event.registrations[0];
+
+			if (registration?.type === "NOT_ATTENDING") continue;
 
 			const typeLabel = getEventTypeLabel(event.eventType);
 			const start = event.startAt;
 			const end = event.endAt ?? new Date(start.getTime() + 60 * 60 * 1000);
+			const eventUrl = `${baseUrl}/lag/${team.id}`;
+			const rsvpBase = `${rsvpTokenBase}/${event.id}`;
 
 			const descriptionParts: string[] = [];
 			if (event.note) descriptionParts.push(event.note);
-			descriptionParts.push(`Registrer oppmøte her: ${baseUrl}`);
+
+			let summary: string;
+			if (registration?.type === "ATTENDING") {
+				summary = `✅ ${typeLabel}: ${event.name} – ${team.name}`;
+				descriptionParts.push(
+					`Status: ✅ Du er påmeldt!\n\n❌ Meld deg av her:\n${rsvpBase}/NOT_ATTENDING`,
+				);
+			} else {
+				summary = `❓ ${typeLabel}: ${event.name} – ${team.name}`;
+				descriptionParts.push(
+					`Status: ❓ Du har ikke svart ennå.\n\n✅ Jeg skal:\n${rsvpBase}/ATTENDING\n\n❌ Jeg skal ikke:\n${rsvpBase}/NOT_ATTENDING`,
+				);
+			}
+
+			descriptionParts.push(`Se detaljer:\n${eventUrl}`);
 
 			calendar.createEvent({
 				id: `${event.id}@sporty.tihlde.org`,
-				summary: `${typeLabel}: ${event.name} – ${team.name}`,
+				summary,
 				start,
 				end,
+				stamp: event.updatedAt,
 				status: ICalEventStatus.CONFIRMED,
 				location: event.location ?? undefined,
 				description: descriptionParts.join("\n\n"),
-				url: baseUrl,
+				url: eventUrl,
 			});
 		}
 	}
@@ -84,8 +105,8 @@ export async function GET(
 	const icsOutput = calendar
 		.toString()
 		.replace(
-			"BEGIN:VEVENT",
-			"X-PUBLISHED-TTL:PT15M\r\nREFRESH-INTERVAL;VALUE=DURATION:PT15M\r\nBEGIN:VEVENT",
+			"METHOD:PUBLISH",
+			"METHOD:PUBLISH\r\nX-PUBLISHED-TTL:PT15M\r\nREFRESH-INTERVAL;VALUE=DURATION:PT15M",
 		);
 
 	return new Response(icsOutput, {

--- a/src/app/api/calendar/[token]/route.ts
+++ b/src/app/api/calendar/[token]/route.ts
@@ -75,12 +75,12 @@ export async function GET(
 
 			let summary: string;
 			if (registration?.type === "ATTENDING") {
-				summary = `✅ ${typeLabel}: ${event.name} – ${team.name}`;
+				summary = `✅ ${team.name} – ${typeLabel}: ${event.name}`;
 				descriptionParts.push(
 					`Status: ✅ Du er påmeldt!\n\n❌ Meld deg av her:\n${rsvpBase}/NOT_ATTENDING`,
 				);
 			} else {
-				summary = `❓ ${typeLabel}: ${event.name} – ${team.name}`;
+				summary = `❓ ${team.name} – ${typeLabel}: ${event.name}`;
 				descriptionParts.push(
 					`Status: ❓ Du har ikke svart ennå.\n\n✅ Jeg skal:\n${rsvpBase}/ATTENDING\n\n❌ Jeg skal ikke:\n${rsvpBase}/NOT_ATTENDING`,
 				);

--- a/src/app/api/calendar/[token]/route.ts
+++ b/src/app/api/calendar/[token]/route.ts
@@ -1,4 +1,4 @@
-import ical, { ICalCalendarMethod } from "ical-generator";
+import ical, { ICalCalendarMethod, ICalEventStatus } from "ical-generator";
 import { env } from "~/env";
 import { getEventTypeLabel } from "~/lib/event-presentation";
 import { db } from "~/server/db";
@@ -26,6 +26,7 @@ export async function GET(
 					id: true,
 					name: true,
 					events: {
+						orderBy: { startAt: "asc" },
 						select: {
 							id: true,
 							name: true,
@@ -49,21 +50,15 @@ export async function GET(
 
 	const calendar = ical({
 		name: `TIHLDE Idrett – ${user.name}`,
-		timezone: "Europe/Oslo",
 		prodId: { company: "TIHLDE", product: "Sporty", language: "NO" },
 		method: ICalCalendarMethod.PUBLISH,
 	});
-	calendar.x("X-PUBLISHED-TTL", "PT15M");
 
 	for (const membership of memberships) {
 		const { team } = membership;
 
 		for (const event of team.events) {
-			const myRegistration = event.registrations[0];
-
-			if (myRegistration?.type === "NOT_ATTENDING") {
-				continue;
-			}
+			if (event.registrations[0]?.type === "NOT_ATTENDING") continue;
 
 			const typeLabel = getEventTypeLabel(event.eventType);
 			const start = event.startAt;
@@ -78,6 +73,7 @@ export async function GET(
 				summary: `${typeLabel}: ${event.name} – ${team.name}`,
 				start,
 				end,
+				status: ICalEventStatus.CONFIRMED,
 				location: event.location ?? undefined,
 				description: descriptionParts.join("\n\n"),
 				url: baseUrl,
@@ -85,7 +81,14 @@ export async function GET(
 		}
 	}
 
-	return new Response(calendar.toString(), {
+	const icsOutput = calendar
+		.toString()
+		.replace(
+			"BEGIN:VEVENT",
+			"X-PUBLISHED-TTL:PT15M\r\nREFRESH-INTERVAL;VALUE=DURATION:PT15M\r\nBEGIN:VEVENT",
+		);
+
+	return new Response(icsOutput, {
 		status: 200,
 		headers: {
 			"Content-Type": "text/calendar; charset=utf-8",

--- a/src/app/api/calendar/[token]/route.ts
+++ b/src/app/api/calendar/[token]/route.ts
@@ -1,0 +1,98 @@
+import ical, { ICalCalendarMethod } from "ical-generator";
+import { env } from "~/env";
+import { getEventTypeLabel } from "~/lib/event-presentation";
+import { db } from "~/server/db";
+
+export async function GET(
+	_request: Request,
+	{ params }: { params: Promise<{ token: string }> },
+) {
+	const { token } = await params;
+
+	const user = await db.user.findUnique({
+		where: { calendarToken: token },
+		select: { id: true, name: true },
+	});
+
+	if (!user) {
+		return new Response("Not found", { status: 404 });
+	}
+
+	const memberships = await db.teamMember.findMany({
+		where: { userId: user.id },
+		select: {
+			team: {
+				select: {
+					id: true,
+					name: true,
+					events: {
+						select: {
+							id: true,
+							name: true,
+							eventType: true,
+							startAt: true,
+							endAt: true,
+							location: true,
+							note: true,
+							registrations: {
+								where: { userId: user.id },
+								select: { type: true },
+							},
+						},
+					},
+				},
+			},
+		},
+	});
+
+	const baseUrl = env.NEXT_PUBLIC_URL ?? "https://sporty.tihlde.org";
+
+	const calendar = ical({
+		name: `TIHLDE Idrett – ${user.name}`,
+		timezone: "Europe/Oslo",
+		prodId: { company: "TIHLDE", product: "Sporty", language: "NO" },
+		method: ICalCalendarMethod.PUBLISH,
+	});
+	calendar.x("X-PUBLISHED-TTL", "PT15M");
+
+	for (const membership of memberships) {
+		const { team } = membership;
+
+		for (const event of team.events) {
+			const myRegistration = event.registrations[0];
+
+			if (myRegistration?.type === "NOT_ATTENDING") {
+				continue;
+			}
+
+			const typeLabel = getEventTypeLabel(event.eventType);
+			const start = event.startAt;
+			const end = event.endAt ?? new Date(start.getTime() + 60 * 60 * 1000);
+
+			const descriptionParts: string[] = [];
+			if (event.note) descriptionParts.push(event.note);
+			descriptionParts.push(`Registrer oppmøte her: ${baseUrl}`);
+
+			calendar.createEvent({
+				id: `${event.id}@sporty.tihlde.org`,
+				summary: `${typeLabel}: ${event.name} – ${team.name}`,
+				start,
+				end,
+				location: event.location ?? undefined,
+				description: descriptionParts.join("\n\n"),
+				url: baseUrl,
+			});
+		}
+	}
+
+	return new Response(calendar.toString(), {
+		status: 200,
+		headers: {
+			"Content-Type": "text/calendar; charset=utf-8",
+			"Content-Disposition": 'attachment; filename="tihlde-sporty.ics"',
+			"Cache-Control": "no-cache, no-store, must-revalidate",
+			Pragma: "no-cache",
+			Expires: "0",
+		},
+	});
+}

--- a/src/app/api/rsvp/[token]/[eventId]/[status]/route.ts
+++ b/src/app/api/rsvp/[token]/[eventId]/[status]/route.ts
@@ -1,0 +1,59 @@
+import type { RegistrationType } from "@prisma/client";
+import { NextResponse } from "next/server";
+import { env } from "~/env";
+import { db } from "~/server/db";
+
+const VALID_STATUSES: RegistrationType[] = ["ATTENDING", "NOT_ATTENDING"];
+
+export async function GET(
+	_request: Request,
+	{
+		params,
+	}: { params: Promise<{ token: string; eventId: string; status: string }> },
+) {
+	const { token, eventId, status } = await params;
+
+	const baseUrl = env.NEXT_PUBLIC_URL ?? "https://sporty.tihlde.org";
+
+	if (!VALID_STATUSES.includes(status as RegistrationType)) {
+		return new Response("Invalid status", { status: 400 });
+	}
+
+	const [user, event] = await Promise.all([
+		db.user.findUnique({
+			where: { calendarToken: token },
+			select: { id: true },
+		}),
+		db.teamEvent.findUnique({
+			where: { id: eventId },
+			select: { teamId: true, name: true },
+		}),
+	]);
+
+	if (!user) {
+		return new Response("Not found", { status: 404 });
+	}
+
+	if (!event) {
+		return new Response("Event not found", { status: 404 });
+	}
+
+	const membership = await db.teamMember.findUnique({
+		where: { userId_teamId: { userId: user.id, teamId: event.teamId } },
+		select: { id: true },
+	});
+
+	if (!membership) {
+		return new Response("Not a team member", { status: 403 });
+	}
+
+	await db.registration.upsert({
+		where: { userId_eventId: { userId: user.id, eventId } },
+		update: { type: status as RegistrationType },
+		create: { userId: user.id, eventId, type: status as RegistrationType },
+	});
+
+	return NextResponse.redirect(
+		`${baseUrl}/rsvp/bekreftet?rsvp=${status}&event=${encodeURIComponent(event.name)}`,
+	);
+}

--- a/src/app/rsvp/bekreftet/page.tsx
+++ b/src/app/rsvp/bekreftet/page.tsx
@@ -1,0 +1,64 @@
+import { CheckCircle2, HelpCircle, XCircle } from "lucide-react";
+import type { Metadata } from "next";
+import Link from "next/link";
+import TihldeLogo from "~/components/logo";
+import { Button } from "~/components/ui/button";
+
+export const metadata: Metadata = {
+	title: "Svar registrert | TIHLDE Idrett",
+};
+
+interface BekreftedPageProps {
+	searchParams: Promise<{ rsvp?: string; event?: string }>;
+}
+
+export default async function BekreftedPage({
+	searchParams,
+}: BekreftedPageProps) {
+	const { rsvp, event: eventName } = await searchParams;
+
+	const isAttending = rsvp === "ATTENDING";
+	const isNotAttending = rsvp === "NOT_ATTENDING";
+
+	return (
+		<div className="flex min-h-dvh flex-col items-center justify-center gap-10 px-4">
+			<TihldeLogo size="small" />
+
+			<div className="flex w-full max-w-xs flex-col items-center gap-6 text-center">
+				{isAttending && (
+					<CheckCircle2
+						className="h-16 w-16 text-green-500"
+						strokeWidth={1.5}
+					/>
+				)}
+				{isNotAttending && (
+					<XCircle
+						className="h-16 w-16 text-foreground-secondary"
+						strokeWidth={1.5}
+					/>
+				)}
+				{!isAttending && !isNotAttending && (
+					<HelpCircle
+						className="h-16 w-16 text-foreground-secondary"
+						strokeWidth={1.5}
+					/>
+				)}
+
+				<div className="space-y-2">
+					<h1 className="font-bold text-2xl text-foreground-primary">
+						{isAttending && "Du er påmeldt!"}
+						{isNotAttending && "Du er avmeldt."}
+						{!isAttending && !isNotAttending && "Svar registrert."}
+					</h1>
+					{eventName && (
+						<p className="text-base text-foreground-secondary">{eventName}</p>
+					)}
+				</div>
+
+				<Button asChild className="w-full">
+					<Link href="/">Gå til appen</Link>
+				</Button>
+			</div>
+		</div>
+	);
+}

--- a/src/app/rsvp/bekreftet/page.tsx
+++ b/src/app/rsvp/bekreftet/page.tsx
@@ -56,7 +56,7 @@ export default async function BekreftedPage({
 				</div>
 
 				<Button asChild className="w-full">
-					<Link href="/">Gå til appen</Link>
+					<Link href="/">Gå til hovedsiden</Link>
 				</Button>
 			</div>
 		</div>

--- a/src/server/api/me/calendar/router.ts
+++ b/src/server/api/me/calendar/router.ts
@@ -1,0 +1,41 @@
+import { TRPCError } from "@trpc/server";
+import { authorizedProcedure, createTRPCRouter } from "~/server/api/trpc";
+
+export const calendarRouter = createTRPCRouter({
+	getOrCreateToken: authorizedProcedure.query(async ({ ctx }) => {
+		const user = await ctx.db.user.findUniqueOrThrow({
+			where: { id: ctx.user.id },
+			select: { calendarToken: true },
+		});
+
+		if (user.calendarToken) {
+			return { token: user.calendarToken };
+		}
+
+		const updated = await ctx.db.user.update({
+			where: { id: ctx.user.id },
+			data: { calendarToken: crypto.randomUUID() },
+			select: { calendarToken: true },
+		});
+
+		if (!updated.calendarToken) {
+			throw new TRPCError({ code: "INTERNAL_SERVER_ERROR" });
+		}
+
+		return { token: updated.calendarToken };
+	}),
+
+	regenerateToken: authorizedProcedure.mutation(async ({ ctx }) => {
+		const updated = await ctx.db.user.update({
+			where: { id: ctx.user.id },
+			data: { calendarToken: crypto.randomUUID() },
+			select: { calendarToken: true },
+		});
+
+		if (!updated.calendarToken) {
+			throw new TRPCError({ code: "INTERNAL_SERVER_ERROR" });
+		}
+
+		return { token: updated.calendarToken };
+	}),
+});

--- a/src/server/api/me/router.ts
+++ b/src/server/api/me/router.ts
@@ -1,6 +1,8 @@
 import { createTRPCRouter } from "~/server/api/trpc";
+import { calendarRouter } from "./calendar/router";
 import { teamRouter } from "./team/router";
 
 export const meRouter = createTRPCRouter({
 	team: teamRouter,
+	calendar: calendarRouter,
 });


### PR DESCRIPTION
Brukere kan abonnere på kalender feeden ved å subscribe på Sporty kalenderen generert av iCal 

Man får da opp events i den personlige kalenderen som synkroniseres jevnlig med sporty siden. Events man ikke har registrert påmelding på vises, og i beskrivelsen har man lenker til å melde seg av/på ved hjelp av token og eventId. Når man melder seg av vil den forsvinne fra kalender feeden (tar litt tid, men Apple kalender kan oppdateres manuelt). 

Lenkene i kalender feeden sender brukeren til en ny bekreftelses side.
Kalendertokenen legges til i User modellen som genereres i Abonner på kalender dialogen