### PR TITLE
feat(auth): logg inn via Photon OIDC i stedet for Lepton

### DIFF
--- a/src/actions/auth.ts
+++ b/src/actions/auth.ts
@@ -1,184 +1,72 @@
 "use server";
 
-import { cookies } from "next/headers";
-import type { z } from "zod";
-import { SignInInputSchema } from "~/schemas";
+import { headers } from "next/headers";
+import { env } from "~/env";
+import { auth } from "~/lib/auth";
 import { db } from "~/server/db";
-import type { MembershipResponse, TIHLDEUser } from "~/types";
 
-export interface ActionResponse<T> {
-	fieldError?: Partial<Record<keyof T, string | undefined>>;
-	formError?: string;
-	userData?: {
-		fullName: string;
-		email: string;
-		username: string;
-		isNewUser: boolean;
-	};
-}
+/**
+ * Standardverdien gjentas her med vilje. `SKIP_ENV_VALIDATION` gjør at t3-env
+ * returnerer process.env rått, uten skjemaets default — og siden dette leses
+ * på modulnivå, ville `.replace` på undefined felt hele bygget når Next samler
+ * sidedata.
+ */
+const ISSUER = env.PHOTON_ISSUER ?? "https://photon.tihlde.org/api/auth";
+const API_URL = ISSUER.replace(/\/auth$/, "");
 
-export async function login(
-	formData: FormData,
-): Promise<ActionResponse<z.infer<typeof SignInInputSchema>>> {
-	const obj = Object.fromEntries(formData.entries());
+export type PhotonMembership = {
+	slug: string;
+	name: string;
+	membership: { role: "member" | "leader" } | null;
+};
 
-	const parsed = SignInInputSchema.safeParse(obj);
-	if (!parsed.success) {
-		const err = parsed.error.flatten();
-		return {
-			fieldError: {
-				username: err.fieldErrors.username?.[0],
-				password: err.fieldErrors.password?.[0],
-			},
-		};
-	}
+/**
+ * Access-tokenet better-auth lagret da brukeren logget inn via Photon.
+ *
+ * Tokenet ligger på account-raden, ikke i en egen cookie som før: OAuth-flyten
+ * eier det, og å speile det ut i en cookie ville gitt to kilder som kommer i
+ * utakt når det fornyes.
+ */
+async function getPhotonAccessToken(): Promise<string | null> {
+	const session = await auth.api.getSession({ headers: await headers() });
+	if (!session?.user?.id) return null;
 
-	const { username, password } = parsed.data;
-
-	// Call Lepton API
-	try {
-		const response = await fetch("https://api.tihlde.org/auth/login/", {
-			method: "POST",
-			headers: {
-				"Content-Type": "application/json",
-			},
-			body: JSON.stringify({ user_id: username, password }),
-		});
-
-		const data = await response.json();
-		if (!response.ok) {
-			throw new Error(data.detail);
-		}
-
-		const userData = await getMyUserInfo(data.token);
-		if (!userData) {
-			throw new Error("Kunne ikke hente brukerdata.");
-		}
-
-		// Add token to user in cookies
-		const cookiesStore = await cookies();
-		cookiesStore.set("tihlde_token", data.token, { httpOnly: true, path: "/" });
-
-		// Check if email is taken
-		const emailTaken = await db.user.findUnique({
-			where: {
-				email: userData.email.toLowerCase(),
-			},
-		});
-
-		if (emailTaken && emailTaken.username !== userData.user_id) {
-			throw new Error(
-				"E-postadressen er allerede i bruk med en annen konto fra TIHLDE.",
-			);
-		}
-
-		// Check if user exists
-		const existingUser = await db.user.findUnique({
-			where: {
-				email: userData.email.toLowerCase(),
-				username: userData.user_id,
-			},
-		});
-
-		// If not, create user
-		if (!existingUser) {
-			console.log("Creating new user...");
-			return {
-				userData: {
-					fullName: `${userData.first_name} ${userData.last_name}`,
-					email: userData.email.toLowerCase(),
-					username: userData.user_id,
-					isNewUser: true,
-				},
-			};
-		}
-
-		return {
-			userData: {
-				fullName: `${userData.first_name} ${userData.last_name}`,
-				email: userData.email.toLowerCase(),
-				username: userData.user_id,
-				isNewUser: false,
-			},
-		};
-	} catch (e) {
-		if (e instanceof Error) {
-			return {
-				formError: e.message,
-			};
-		}
-		return {
-			formError: "Det oppstod en feil under innlogging. Prøv igjen senere.",
-		};
-	}
-}
-
-export async function getUserInfo(
-	username: string,
-): Promise<TIHLDEUser | null> {
-	if (!username) {
-		return null;
-	}
-
-	const response = await fetch(`https://api.tihlde.org/users/${username}/`, {
-		headers: {
-			"Content-Type": "application/json",
-		},
+	const account = await db.account.findFirst({
+		where: { userId: session.user.id, providerId: "photon" },
+		select: { accessToken: true, accessTokenExpiresAt: true },
 	});
 
-	if (!response.ok) {
+	if (!account?.accessToken) return null;
+
+	// Et utløpt token gir 401 uansett; å returnere null her lar kalleren si
+	// «logg inn på nytt» framfor å vise en generisk feil.
+	if (
+		account.accessTokenExpiresAt &&
+		account.accessTokenExpiresAt.getTime() <= Date.now()
+	) {
 		return null;
 	}
 
-	return await response.json();
+	return account.accessToken;
 }
 
-export async function getMyUserInfo(token: string): Promise<TIHLDEUser | null> {
-	if (!token) {
-		return null;
-	}
+/**
+ * Gruppene brukeren er medlem av, hentet fra Photon.
+ *
+ * Erstatter Leptons /users/me/memberships/. Formen er snudd: Photon returnerer
+ * gruppene med medlemskapet nøstet inni, der Lepton returnerte medlemskap med
+ * gruppa nøstet inni.
+ */
+export async function getUserMemberships(): Promise<PhotonMembership[] | null> {
+	const token = await getPhotonAccessToken();
+	if (!token) return null;
 
-	const response = await fetch("https://api.tihlde.org/users/me/", {
-		headers: {
-			"x-csrf-token": token,
-		},
+	const response = await fetch(`${API_URL}/groups/mine`, {
+		headers: { Authorization: `Bearer ${token}` },
+		cache: "no-store",
 	});
 
-	if (!response.ok) {
-		return null;
-	}
+	if (!response.ok) return null;
 
-	return await response.json();
-}
-
-export async function getUserMemberships(
-	token: string,
-): Promise<MembershipResponse | null> {
-	if (!token) {
-		return null;
-	}
-
-	const response = await fetch("https://api.tihlde.org/users/me/memberships/", {
-		headers: {
-			"x-csrf-token": token,
-		},
-	});
-
-	if (!response.ok) {
-		return null;
-	}
-
-	return await response.json();
-}
-
-export async function getTIHLDEToken(): Promise<string | null> {
-	const cookiesStore = await cookies();
-	const token = cookiesStore.get("tihlde_token")?.value;
-
-	return token || null;
-}
-
-export async function clearTIHLDEToken() {
-	const cookiesStore = await cookies();
-	cookiesStore.delete("tihlde_token");
+	return (await response.json()) as PhotonMembership[];
 }

--- a/src/components/navigation/logout.tsx
+++ b/src/components/navigation/logout.tsx
@@ -4,7 +4,6 @@ import { Loader2, LogOut } from "lucide-react";
 import { useRouter } from "next/navigation";
 import { useTransition } from "react";
 import { toast } from "sonner";
-import { clearTIHLDEToken } from "~/actions";
 import { authClient } from "~/lib/auth-client";
 
 export default function Logout() {
@@ -18,7 +17,8 @@ export default function Logout() {
 				if (res.error) {
 					toast.error(res.error.message);
 				} else {
-					await clearTIHLDEToken();
+					// Ingen egen TIHLDE-cookie å rydde lenger — tokenet ligger på
+					// account-raden og forsvinner med sesjonen.
 					router.replace("/");
 				}
 			} catch {

--- a/src/components/navigation/sign-in.tsx
+++ b/src/components/navigation/sign-in.tsx
@@ -1,16 +1,9 @@
 "use client";
 
-import { zodResolver } from "@hookform/resolvers/zod";
 import { Loader2 } from "lucide-react";
-import { useRouter } from "next/navigation";
-import { useState, useTransition } from "react";
-import { useForm } from "react-hook-form";
+import { useState } from "react";
 import { toast } from "sonner";
-import type z from "zod";
-import { login } from "~/actions";
 import { authClient } from "~/lib/auth-client";
-import { SignInInputSchema } from "~/schemas";
-import FormInput from "../form/input";
 import TihldeLogo from "../logo";
 import { Button } from "../ui/button";
 import {
@@ -21,70 +14,35 @@ import {
 	DialogTitle,
 	DialogTrigger,
 } from "../ui/dialog";
-import { Form } from "../ui/form";
 
 export default function LoginForm() {
 	const [open, setOpen] = useState<boolean>(false);
-	const [isPending, startTransition] = useTransition();
-	const router = useRouter();
+	const [isPending, setIsPending] = useState<boolean>(false);
 
-	const form = useForm<z.infer<typeof SignInInputSchema>>({
-		resolver: zodResolver(SignInInputSchema),
-		defaultValues: {
-			username: "",
-			password: "",
-		},
-	});
+	/**
+	 * Sender brukeren til tihlde.org. Passordet skrives inn der, aldri her —
+	 * denne appen ser det ikke, og Feide-innlogging blir tilgjengelig på
+	 * kjøpet. Ingen redirect tilbake å håndtere: better-auth setter sesjonen i
+	 * callback-ruten og sender brukeren videre selv.
+	 */
+	const onSignIn = async () => {
+		setIsPending(true);
+		try {
+			const { error } = await authClient.signIn.oauth2({
+				providerId: "photon",
+				callbackURL: "/",
+			});
 
-	const onSubmit = async (values: z.infer<typeof SignInInputSchema>) => {
-		startTransition(async () => {
-			try {
-				const formData = new FormData();
-				formData.append("username", values.username);
-				formData.append("password", values.password);
-				const loginResponse = await login(formData);
-				if (loginResponse.formError || !loginResponse.userData) {
-					toast.error(loginResponse.formError);
-					form.reset({
-						password: "",
-						username: "",
-					});
-					return;
-				}
-
-				if (loginResponse.userData.isNewUser) {
-					const { error } = await authClient.signUp.email({
-						email: loginResponse.userData.email,
-						password: values.password,
-						name: loginResponse.userData.fullName,
-						username: loginResponse.userData.username,
-						isAdmin: false,
-					});
-
-					if (error) {
-						toast.error(error.message || "Noe gikk galt under innloggingen.");
-						return;
-					}
-				} else {
-					const { error } = await authClient.signIn.email({
-						password: values.password,
-						email: loginResponse.userData.email,
-					});
-
-					if (error) {
-						toast.error(error.message || "Noe gikk galt under innloggingen.");
-						return;
-					}
-				}
-
-				setOpen(false);
-				router.refresh();
-			} catch {
-				toast.error(
-					"Noe gikk galt under innloggingen. Vennligst prøv igjen senere.",
-				);
+			if (error) {
+				toast.error(error.message ?? "Noe gikk galt under innloggingen.");
+				setIsPending(false);
 			}
-		});
+		} catch {
+			toast.error(
+				"Noe gikk galt under innloggingen. Vennligst prøv igjen senere.",
+			);
+			setIsPending(false);
+		}
 	};
 
 	return (
@@ -105,37 +63,23 @@ export default function LoginForm() {
 							Velkommen tilbake
 						</DialogTitle>
 						<DialogDescription className="sm:text-center">
-							Bruk din TIHLDE bruker for å logge inn
+							Du sendes til tihlde.org for å logge inn
 						</DialogDescription>
 					</DialogHeader>
 				</div>
 
-				<Form {...form}>
-					<form className="space-y-6" onSubmit={form.handleSubmit(onSubmit)}>
-						<FormInput
-							form={form}
-							name="username"
-							required
-							label="Brukernavn"
-						/>
-
-						<FormInput
-							form={form}
-							name="password"
-							type="password"
-							required
-							label="Passord"
-						/>
-
-						<Button type="submit" className="w-full" disabled={isPending}>
-							{isPending ? (
-								<Loader2 className="animate-spin" />
-							) : (
-								<span>Logg inn</span>
-							)}
-						</Button>
-					</form>
-				</Form>
+				<Button
+					type="button"
+					className="w-full"
+					disabled={isPending}
+					onClick={onSignIn}
+				>
+					{isPending ? (
+						<Loader2 className="animate-spin" />
+					) : (
+						<span>Logg inn med TIHLDE</span>
+					)}
+				</Button>
 			</DialogContent>
 		</Dialog>
 	);

--- a/src/env.js
+++ b/src/env.js
@@ -14,6 +14,15 @@ export const env = createEnv({
 		BETTER_AUTH_SECRET: z.string().optional(),
 		EMAIL_API_KEY: z.string().optional(),
 		VAPID_PRIVATE_KEY: z.string().optional(),
+		// Registrer klienten under /admin/oauth-clients på tihlde.org.
+		// Redirect-URI: <origin>/api/auth/oauth2/callback/photon
+		// Valgfrie som resten her, så bygg uten dem ikke faller på validering.
+		PHOTON_CLIENT_ID: z.string().optional(),
+		PHOTON_CLIENT_SECRET: z.string().optional(),
+		PHOTON_ISSUER: z
+			.string()
+			.url()
+			.default("https://photon.tihlde.org/api/auth"),
 	},
 
 	/**
@@ -38,6 +47,9 @@ export const env = createEnv({
 		EMAIL_API_KEY: process.env.EMAIL_API_KEY,
 		VAPID_PRIVATE_KEY: process.env.VAPID_PRIVATE_KEY,
 		NEXT_PUBLIC_VAPID_PUBLIC_KEY: process.env.NEXT_PUBLIC_VAPID_PUBLIC_KEY,
+		PHOTON_CLIENT_ID: process.env.PHOTON_CLIENT_ID,
+		PHOTON_CLIENT_SECRET: process.env.PHOTON_CLIENT_SECRET,
+		PHOTON_ISSUER: process.env.PHOTON_ISSUER,
 	},
 	/**
 	 * Run `build` or `dev` with `SKIP_ENV_VALIDATION` to skip env validation. This is especially

--- a/src/lib/auth-client.ts
+++ b/src/lib/auth-client.ts
@@ -1,8 +1,13 @@
-import { inferAdditionalFields } from "better-auth/client/plugins";
+import {
+	genericOAuthClient,
+	inferAdditionalFields,
+} from "better-auth/client/plugins";
 import { createAuthClient } from "better-auth/react";
 
 export const authClient = createAuthClient({
 	plugins: [
+		// Gir signIn.oauth2, som starter Photon-flyten.
+		genericOAuthClient(),
 		inferAdditionalFields({
 			user: {
 				username: {

--- a/src/lib/auth.ts
+++ b/src/lib/auth.ts
@@ -1,6 +1,7 @@
 import { betterAuth } from "better-auth";
 import { prismaAdapter } from "better-auth/adapters/prisma";
 import { nextCookies } from "better-auth/next-js";
+import { genericOAuth } from "better-auth/plugins";
 import { env } from "~/env";
 import { db } from "~/server/db";
 
@@ -9,8 +10,11 @@ export const auth = betterAuth({
 	database: prismaAdapter(db, {
 		provider: "postgresql",
 	}),
+	// Passord logges inn med på tihlde.org, ikke her. Lepton skal avvikles, og
+	// denne appen skal uansett ikke ta imot medlemmenes passord for å veksle
+	// dem inn i et token et annet sted.
 	emailAndPassword: {
-		enabled: true,
+		enabled: false,
 	},
 	session: {
 		expiresIn: 60 * 60 * 24 * 120, // 120 days,
@@ -36,5 +40,43 @@ export const auth = betterAuth({
 		},
 	},
 	trustedOrigins: ["*"],
-	plugins: [nextCookies()],
+	plugins: [
+		genericOAuth({
+			config: [
+				{
+					providerId: "photon",
+					// Samme grunn som i actions/auth.ts: med SKIP_ENV_VALIDATION
+					// uteblir skjemaets default, og «undefined» ville havnet
+					// midt i URL-en.
+					discoveryUrl: `${env.PHOTON_ISSUER ?? "https://photon.tihlde.org/api/auth"}/.well-known/openid-configuration`,
+					// Valgfrie i env-skjemaet, som resten av variablene her, så
+					// bygg uten dem ikke faller på validering. Mangler de i
+					// runtime, avviser Photon autorisasjonen — det er synlig
+					// med én gang og bare for innlogging.
+					clientId: env.PHOTON_CLIENT_ID ?? "",
+					clientSecret: env.PHOTON_CLIENT_SECRET ?? "",
+					scopes: ["openid", "profile", "email"],
+					/**
+					 * `username` er et påkrevd felt på brukeren her, men Photon
+					 * har det ikke i standard-claimene. Uten dette faller
+					 * opprettelsen av nye brukere på validering.
+					 *
+					 * E-postens lokaldel er samme verdi Lepton brukte som
+					 * user_id for stud.ntnu.no-kontoer, så eksisterende rader
+					 * kjenner seg igjen.
+					 */
+					// Typen til mapProfileToUser kjenner bare standardfeltene på
+					// brukeren, ikke additionalFields, så username må castes inn.
+					mapProfileToUser: (profile) =>
+						({
+							username:
+								(profile.preferred_username as string | undefined) ??
+								profile.email?.split("@")[0] ??
+								profile.sub,
+						}) as unknown as Record<string, never>,
+				},
+			],
+		}),
+		nextCookies(),
+	],
 });

--- a/src/server/api/me/team/membership/controller/sync.ts
+++ b/src/server/api/me/team/membership/controller/sync.ts
@@ -1,19 +1,20 @@
 import type { TeamRole } from "@prisma/client";
 import { TRPCError } from "@trpc/server";
-import { getTIHLDEToken, getUserMemberships } from "~/actions";
+import { getUserMemberships } from "~/actions";
 import { type Controller, authorizedProcedure } from "~/server/api/trpc";
 
 const handler: Controller<void, void> = async ({ ctx }) => {
-	// Get TIHLDE token
-	const token = await getTIHLDEToken();
+	// Hentes fra Photon med access-tokenet OAuth-flyten lagret.
+	const membershipResponse = await getUserMemberships();
 
-	// Get memberships from TIHLDE
-	const membershipResponse = await getUserMemberships(token || "");
-
-	const memberships = membershipResponse?.results.map((membership) => ({
-		groupSlug: membership.group.slug,
-		role: membership.membership_type === "MEMBER" ? "USER" : "ADMIN",
-	}));
+	// Photon nøster medlemskapet inni gruppa, motsatt av Lepton. En gruppe
+	// uten membership skal ikke gi ADMIN ved et uhell, så den hoppes over.
+	const memberships = membershipResponse
+		?.filter((group) => group.membership !== null)
+		.map((group) => ({
+			groupSlug: group.slug,
+			role: group.membership?.role === "leader" ? "ADMIN" : "USER",
+		}));
 
 	if (!memberships) {
 		throw new TRPCError({


### PR DESCRIPTION
Del av avviklingen av Lepton.

## Hva

Appen tok imot brukernavn og passord i sitt eget skjema og POSTet dem til Leptons `/auth/login/`. Nå sendes brukeren til tihlde.org og appen ser aldri passordet — Feide-innlogging kommer med på kjøpet.

Proton bruker allerede **better-auth**, samme bibliotek som Photon kjører som OIDC-provider. Koblingen er derfor `genericOAuth`-pluginen, ikke en håndskrevet flyt. `emailAndPassword` er slått av; den var bare der for å speile Lepton-innloggingen inn i den lokale basen.

## Tokenet flyttet

Før lå Lepton-tokenet i en egen `tihlde_token`-cookie ved siden av better-auth-sesjonen. Nå ligger access-tokenet på `account`-raden der OAuth-flyten selv legger det. To kilder til samme token kommer i utakt så snart det fornyes.

## Medlemskapssynking

`/users/me/memberships/` → `/groups/mine`. Formen er snudd: Photon returnerer gruppene med medlemskapet nøstet inni, der Lepton returnerte medlemskap med gruppa nøstet inni. Rollen er `leader` framfor `membership_type !== "MEMBER"`.

En gruppe uten `membership` hoppes over — ellers ville den falt gjennom til ADMIN.

## Verifisert

`tsc --noEmit` rent. Ingen referanser til `api.tihlde.org` igjen i `src/`.

Selve innloggingsrunden er **ikke** kjørt — den krever en registrert OAuth-klient, og Photon har ingen dynamisk klientregistrering.

## Før merge

Registrer klienten i `/admin/oauth-clients` på tihlde.org med **«Offentlig klient» av**, og redirect-URI:

```
https://<origin>/api/auth/oauth2/callback/photon
```

Sett så `PHOTON_CLIENT_ID` og `PHOTON_CLIENT_SECRET`. `PHOTON_ISSUER` har standardverdi og trengs bare mot en lokal Photon.

🤖 Generated with [Claude Code](https://claude.com/claude-code)