### PR TITLE
fix(auth): send PKCE — Photon avviser autorisasjon uten

### DIFF
--- a/src/lib/auth.ts
+++ b/src/lib/auth.ts
@@ -56,6 +56,10 @@ export const auth = betterAuth({
 					clientId: env.PHOTON_CLIENT_ID ?? "",
 					clientSecret: env.PHOTON_CLIENT_SECRET ?? "",
 					scopes: ["openid", "profile", "email"],
+					// Photon avviser autorisasjon uten PKCE, også for
+					// konfidensielle klienter som denne: «pkce is required for
+					// this client». better-auth har den av som standard.
+					pkce: true,
 					/**
 					 * `username` er et påkrevd felt på brukeren her, men Photon
 					 * har det ikke i standard-claimene. Uten dette faller


### PR DESCRIPTION
Innloggingen som ble merget i #107 **kommer aldri i gang**. Photon svarer:

```
error=invalid_request
error_description=pkce is required for this client
```

## Hvorfor det ikke kom med i #107

Feilen var ikke synlig da. Uten registrerte OAuth-klienter svarte autorisasjonsendepunktet `invalid_client`, og det skjulte PKCE-kravet bak seg. Først da klientene var opprettet kunne kallet komme langt nok til å avsløre det.

Photon krever PKCE av **alle** klienter, også konfidensielle som denne der hemmeligheten ligger trygt på serveren. better-auths `genericOAuth` har `pkce` av som standard — én linje, men den stopper hele innloggingen.

## Verifisert

`tsc --noEmit` rent og `pnpm build` grønt.

Autorisasjonskallet med PKCE og en ekte klient-ID svarer nå `{"redirect":true,"url":"/login?..."}` — altså «send brukeren til innlogging» — der det uten PKCE var en 302 til `error=invalid_request`. Testet mot produksjons-Photon.

Selve runden ende til ende krever en ekte innlogging i nettleseren og er ikke kjørt.

## Merk

Samme feil gjaldt mordvember (#4) og pythons (#191), begge med håndskrevne flyter som manglet `code_challenge`. `projects` bruker Auth.js, som slår på PKCE selv når provideren annonserer det.