### PR TITLE
fix(ci): trigg deploy på push til main

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -2,9 +2,12 @@ name: 'build -> push -> deploy'
 on:
   push:
     branches: [main]
+    # `./**` matcher ingenting — path-filtre er repo-relative uten `./`, så
+    # push til main har aldri trigget denne workflowen. Eneste kjøringer siden
+    # mai 2026 var manuelle workflow_dispatch, og merget kode ble derfor
+    # liggende ubygget.
     paths:
-      - ./**
-      - .github/workflows/deploy.yml
+      - '**'
   workflow_dispatch:
 
 concurrency:


### PR DESCRIPTION
## Hvorfor sporty.tihlde.org fortsatt kjører gammel kode

PR #107 og #108 er merget, men aldri bygget. Deployed build svarer fortsatt slik:

| Rute | Svar |
|---|---|
| `POST /api/auth/sign-in/email` | 400 — ruta finnes |
| `POST /api/auth/sign-in/oauth2` | 404 — genericOAuth mangler |

Årsaken er path-filteret i workflowen:

```yaml
paths:
  - ./**
```

Path-filtre i GitHub Actions er repo-relative og uten `./`-prefiks. `./**` matcher ingen filer, så `push` til main har aldri trigget workflowen. Siste kjøring var en manuell `workflow_dispatch` 4. mai 2026.

## Fiksen

`- '**'` — samme mønster som Photon bruker.

## ⚠️ Ikke merg før secrets er på plass

Denne PR-en gjør at neste push til main faktisk deployer. Den merget auth-koden slår av e-post/passord-innlogging og krever `PHOTON_CLIENT_ID`, `PHOTON_CLIENT_SECRET` og `PHOTON_ISSUER` på Drift.

Deployer man uten dem, mister sporty.tihlde.org den innloggingen som virker i dag og får ingen ny. Sett variablene først.

🤖 Generated with [Claude Code](https://claude.com/claude-code)