### PR TITLE
chore(ci): frys automatisk deploy til Photon-secrets er på Drift

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,13 +1,21 @@
 name: 'build -> push -> deploy'
 on:
-  push:
-    branches: [main]
-    # `./**` matcher ingenting — path-filtre er repo-relative uten `./`, så
-    # push til main har aldri trigget denne workflowen. Eneste kjøringer siden
-    # mai 2026 var manuelle workflow_dispatch, og merget kode ble derfor
-    # liggende ubygget.
-    paths:
-      - '**'
+  # FRYST: automatisk deploy er slått av med vilje.
+  #
+  # main bærer overgangen til Photon-innlogging (#107, #108). Den slår av
+  # e-post/passord-innlogging og krever PHOTON_CLIENT_ID, PHOTON_CLIENT_SECRET
+  # og PHOTON_ISSUER på Drift. Uten dem mister sporty.tihlde.org innloggingen
+  # som virker i dag, og får ingen ny.
+  #
+  # Slik gjenåpner du når variablene er satt — legg tilbake:
+  #
+  #   push:
+  #     branches: [main]
+  #     paths:
+  #       - '**'
+  #
+  # (Det opprinnelige filteret var `./**`, som er repo-relativt-feil og aldri
+  # matchet noe. Derfor lå #107 og #108 ubygget i månedsvis.)
   workflow_dispatch:
 
 concurrency:


### PR DESCRIPTION
## Situasjonen

#109 er merget, og deployen den utløste ble stoppet manuelt mens den kjørte. sporty.tihlde.org er uskadd — den kjører fortsatt mai-bygget, og e-post/passord-innlogging virker.

Men risikoen står: med push-triggeren aktiv vil **hvilken som helst** merge til main deploye. Det er fire åpne PR-er på repoet, og en dependabot-merge er nok til å ta ned innloggingen uten at noen tenker på det.

main bærer nemlig #107 og #108, som slår av e-post/passord og krever `PHOTON_CLIENT_ID`, `PHOTON_CLIENT_SECRET` og `PHOTON_ISSUER` på Drift. Variablene er ikke satt.

## Hvorfor ikke bare reverte #109

En ren revert legger tilbake det opprinnelige filteret:

```yaml
paths:
  - ./**
```

Det er ugyldig — path-filtre er repo-relative uten `./`, så det matcher ingen filer. Det er nettopp derfor #107 og #108 lå ubygget i månedsvis. Å legge tilbake en typo som frys er uærlig: den ser ut som en feil, og neste person retter den og tar ned sporty.

## Denne PR-en

Fjerner `push`-triggeren og forklarer hvorfor, med oppskriften for å legge den tilbake. `workflow_dispatch` står igjen, så deploy kan kjøres bevisst.

Merking av denne PR-en utløser ikke selv en deploy: workflow-fila i den pushede commiten har ingen `push`-trigger.

## Når secretsene er på plass

1. Sett de tre variablene på Drift
2. Revert denne PR-en
3. Kjør deployen — enten via `workflow_dispatch` eller neste push til main
4. Test innlogging på sporty.tihlde.org

🤖 Generated with [Claude Code](https://claude.com/claude-code)